### PR TITLE
Replace one-second sleep with an MPI barrier in NCCL initialization

### DIFF
--- a/horovod/tensorflow/mpi_ops.cc
+++ b/horovod/tensorflow/mpi_ops.cc
@@ -847,8 +847,9 @@ void PerformOperation(TensorTable& tensor_table, MPIResponse response) {
                                     horovod_global.rank))
         nccl_comm = new_nccl_comm;
 
-        // TODO: Rohit (NVIDIA): figure out why we need this sleep
-        std::this_thread::sleep_for(std::chrono::seconds(1));
+        // Barrier helps NCCL to synchronize after initialization and avoid
+        // deadlock that we've been seeing without it.
+        MPI_CHECK(entries, "MPI_Barrier", MPI_Barrier(MPI_COMM_WORLD));
 
         ACTIVITY_END_ALL(entries, timeline)
       }

--- a/setup.py
+++ b/setup.py
@@ -315,7 +315,7 @@ class custom_build_ext(build_ext):
 
 
 setup(name='horovod',
-      version='0.9.8',
+      version='0.9.9',
       packages=find_packages(),
       description='Distributed training framework for TensorFlow.',
       author='Uber Technologies, Inc.',


### PR DESCRIPTION
During initial integration with NCCL, we have observed an issue (hanging) with dynamic NCCL communicator creation via `ncclCommInitRank()` and then immediate call to `ncclAllreduce()` & `cudaStreamSynchronize()` or `cudaEventSynchronize()`.  Stack traces look like this:

```
Thread 55 (Thread 0x7f0085cb9700 (LWP 69796)): 
#0 pthread_cond_wait@@GLIBC_2.3.2 () at ../nptl/sysdeps/unix/sysv/linux/x86_64/pthread_cond_wait.S:185 
#1 0x00007f008a16b1eb in ?? () from /home/asergeev/mpi/nccl/libnccl.so.2 
#2 0x00007f008a1a40e1 in ?? () from /home/asergeev/mpi/nccl/libnccl.so.2 
#3 0x00007f008a1a479e in ?? () from /home/asergeev/mpi/nccl/libnccl.so.2 
#4 0x00007f008a1a6315 in ?? () from /home/asergeev/mpi/nccl/libnccl.so.2 
#5 0x00007f008a1b520d in ?? () from /home/asergeev/mpi/nccl/libnccl.so.2 
#6 0x00007f008a17659d in ?? () from /home/asergeev/mpi/nccl/libnccl.so.2 
#7 0x00007f008a19fabe in ncclAllReduce () from /home/asergeev/mpi/nccl/libnccl.so.2 

Thread 18 (Thread 0x7f69daf6c700 (LWP 80993)): 
#0 sem_wait () at ../nptl/sysdeps/unix/sysv/linux/x86_64/sem_wait.S:85 
#1 0x00007f6a4d474f07 in ?? () from /usr/lib/x86_64-linux-gnu/libcuda.so.1 
---Type <return> to continue, or q <return> to quit--- 
#2 0x00007f6a4d3917e7 in ?? () from /usr/lib/x86_64-linux-gnu/libcuda.so.1 
#3 0x00007f6a4d501782 in ?? () from /usr/lib/x86_64-linux-gnu/libcuda.so.1 
#4 0x00007f6a4d443471 in ?? () from /usr/lib/x86_64-linux-gnu/libcuda.so.1 
#5 0x00007f6a4d37376d in ?? () from /usr/lib/x86_64-linux-gnu/libcuda.so.1 
#6 0x00007f6a4d4a8ae2 in cuEventSynchronize () from /usr/lib/x86_64-linux-gnu/libcuda.so.1 
#7 0x00007f6a3b4d362e in ?? () from /usr/local/cuda/lib64/libcudart.so.8.0 
#8 0x00007f6a3b505bd4 in cudaEventSynchronize () from /usr/local/cuda/lib64/libcudart.so.8.0 
```

OR

```
Thread 38 (Thread 0x7fada4fbf700 (LWP 90412)): 
#0 0x00007ffd645b0a5e in clock_gettime () 
#1 0x00007fadd110627d in __GI___clock_gettime (clock_id=<optimized out>, tp=<optimized out>) at ../sysdeps/unix/clock_gettime.c:115 
#2 0x00007fad4322c1ae in ?? () from /usr/lib/x86_64-linux-gnu/libcuda.so.1 
#3 0x00007fad432b95c5 in ?? () from /usr/lib/x86_64-linux-gnu/libcuda.so.1 
#4 0x00007fad43217eb3 in ?? () from /usr/lib/x86_64-linux-gnu/libcuda.so.1 
#5 0x00007fad43218009 in ?? () from /usr/lib/x86_64-linux-gnu/libcuda.so.1 
#6 0x00007fad4313f7a7 in ?? () from /usr/lib/x86_64-linux-gnu/libcuda.so.1 
#7 0x00007fad43272f72 in cuStreamSynchronize () from /usr/lib/x86_64-linux-gnu/libcuda.so.1 
#8 0x00007fad3128bf60 in ?? () from /usr/local/cuda/lib64/libcudart.so.8.0 
#9 0x00007fad312bf47d in cudaStreamSynchronize () from /usr/local/cuda/lib64/libcudart.so.8.0
 ```

While we (and NVIDIA) still don't know the cause of this deadlock, we can replace this one-second sleep with a more reliable solution - an MPI barrier.