### PR TITLE
Support for Cray MPI: custom command to discover MPI compilation flags

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -105,9 +105,13 @@ def get_mpi_flags():
     try:
         mpi_show_output = subprocess.check_output(
             shlex.split(show_command), universal_newlines=True).strip()
+        mpi_show_args = shlex.split(mpi_show_output)
+        if not mpi_show_args[0].startswith('-'):
+            # Open MPI and MPICH print compiler name as a first word, skip it
+            mpi_show_args = mpi_show_args[1:]
         # strip off compiler call portion and always escape each arg
         return ' '.join(['"' + arg.replace('"', '"\'"\'"') + '"'
-                         for arg in shlex.split(mpi_show_output)[1:]])
+                         for arg in mpi_show_args])
     except Exception:
         raise DistutilsPlatformError(
             '%s failed (see error below), is MPI in $PATH?\n'


### PR DESCRIPTION
Cray MPI doesn't have `mpicxx`, so we need the ability to specify the command that will show MPI compilation flags.

Additionally, `mpicxx -show` and `CC --cray-print-opts=all` have slightly different behavior.  Former displays compiler name AND flags, while latter just prints flags.

We assume the flags start with `-`, so if the first word in the result does not start with `-`, we assume that it's the compiler name and skip it.