### PR TITLE
Python 3 compatability fix

### DIFF
--- a/examples/keras_mnist.py
+++ b/examples/keras_mnist.py
@@ -21,7 +21,7 @@ batch_size = 128
 num_classes = 10
 
 # Adjust number of epochs based on number of GPUs.
-epochs = 12 / hvd.size()
+epochs = int(12 / hvd.size())
 
 # Input image dimensions
 img_rows, img_cols = 28, 28


### PR DESCRIPTION
I get a the following error when I try to run in python 3. This is the fix. 
```
  File "keras_mnist.py", line 82, in <module>
    validation_data=(x_test, y_test))
...
TypeError: 'float' object cannot be interpreted as an integer
```