### PR TITLE
Various README updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,10 +117,10 @@ with tf.train.MonitoredTrainingSession(checkpoint_dir=checkpoint_dir,
     mon_sess.run(train_op)
 ```
 
-## Running the Horovod
+## Running Horovod
 
-Below are a couple of examples of commands to run the distributed training. See the [Running the Horovod](docs/running.md)
-page for more instructions, including RoCE/InfiniBand tweaks and dealing with hangs.
+The example commands below show how to run distributed training. See the [Running Horovod](docs/running.md)
+page for more instructions, including RoCE/InfiniBand tweaks and tips for dealing with hangs.
 
 1. To run on a machine with 4 GPUs:
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ with tf.train.MonitoredTrainingSession(checkpoint_dir=checkpoint_dir,
 
 ## Running the Horovod
 
-Below are a couple of examples of commands to run the distributed training. See the [Running the training](docs/running.md)
+Below are a couple of examples of commands to run the distributed training. See the [Running the Horovod](docs/running.md)
 page for more instructions, including RoCE/InfiniBand tweaks and dealing with hangs.
 
 1. To run on a machine with 4 GPUs:

--- a/README.md
+++ b/README.md
@@ -134,11 +134,11 @@ To run on 4 machines with 4 GPUs each using Open MPI:
 $ mpirun -np 16 -x LD_LIBRARY_PATH -H server1:4,server2:4,server3:4,server4:4 python train.py
 ```
 
-If you're using Open MPI and you have RoCE or InfiniBand, we found this custom RDMA queue configuration to help
-performance a lot:
+If you're using Open MPI and you have RoCE or InfiniBand, we found the following `pml` and `btl_openib_receive_queues`
+parameters to help performance a lot:
 
 ```bash
-$ mpirun -np 16 -x LD_LIBRARY_PATH -mca btl_openib_receive_queues P,128,32:P,2048,32:P,12288,32:P,131072,32 -H server1:4,server2:4,server3:4,server4:4 python train.py
+$ mpirun -np 16 -x LD_LIBRARY_PATH -mca pml ob1 -mca btl_openib_receive_queues P,128,32:P,2048,32:P,12288,32:P,131072,32 -H server1:4,server2:4,server3:4,server4:4 python train.py
 ```
 
 Check your MPI documentation for arguments to the `mpirun` command on your system.

--- a/README.md
+++ b/README.md
@@ -15,14 +15,8 @@ it on many GPUs faster. This has two aspects:
 1. How much modifications does one have to make to a program to make it distributed, and how easy is it to run it.
 2. How much faster would it run in distributed mode?
 
-Internally at Uber we found that it's much easier for people to understand an MPI model that requires minimal changes to
-source code than to understand how to set up regular Distributed TensorFlow.
-
-To give some perspective on that, [this commit](https://github.com/alsrgv/benchmarks/commit/86bf2f9269dbefb4e57a8b66ed260c8fab84d6c7) 
-into our fork of TF Benchmarks shows how much code can be removed if one doesn't need to worry about towers and manually
-averaging gradients across them, `tf.Server()`, `tf.ClusterSpec()`, `tf.train.SyncReplicasOptimizer()`, 
-`tf.train.replicas_device_setter()` and so on. If none of these things makes sense to you - don't worry, you don't have to 
-learn them if you use Horovod.
+Internally at Uber we found the MPI model to be much more straightforward and require far less code changes than the
+Distributed TensorFlow with parameter servers. See the [Usage](#usage) section for more details.
 
 In addition to being easy to use, Horovod is fast. Below is a chart representing the benchmark that was done on 32
 servers with 4 Pascal GPUs each connected by RoCE-capable 25 Gbit/s network:
@@ -30,6 +24,7 @@ servers with 4 Pascal GPUs each connected by RoCE-capable 25 Gbit/s network:
 ![128-GPU Benchmark](https://user-images.githubusercontent.com/16640218/31681220-7453e760-b32b-11e7-9ba3-6d01f83b7748.png)
 
 Horovod achieves 90% scaling efficiency for both Inception V3 and ResNet-101, and 79% scaling efficiency for VGG-16.
+See the [Benchmarks](docs/benchmarks.md) page to find out how to reproduce these numbers.
 
 While installing MPI and NCCL itself may seem like an extra hassle, it only needs to be done once by the team dealing
 with infrastructure, while everyone else in the company who builds the models can enjoy the simplicity of training them at

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -1,0 +1,38 @@
+## Benchmarks
+
+![128-GPU Benchmark](https://user-images.githubusercontent.com/16640218/31681220-7453e760-b32b-11e7-9ba3-6d01f83b7748.png)
+
+The above benchmark was done on 32 servers with 4 Pascal GPUs each connected by RoCE-capable 25 Gbit/s network. Horovod
+achieves 90% scaling efficiency for both Inception V3 and ResNet-101, and 79% scaling efficiency for VGG-16.
+
+To reproduce the benchmarks:
+
+1. Install Horovod using the instructions provided on the [Horovod on GPU](gpus.md) page.
+
+2. Clone branch `horovod_v2` of [https://github.com/alsrgv/benchmarks](https://github.com/alsrgv/benchmarks):
+
+```bash
+$ git clone https://github.com/alsrgv/benchmarks
+$ cd benchmarks
+$ git checkout horovod_v2
+```
+
+3. Run the benchmark.
+
+    1. If you have a plain TCP network:
+    
+    ```bash
+    $ mpirun -np 16 -x LD_LIBRARY_PATH -H server1:4,server2:4,server3:4,server4:4 python scripts/tf_cnn_benchmarks/tf_cnn_benchmarks.py --model resnet101 --batch_size 64 --variable_update horovod
+    ```
+
+    2. If you have a network with RoCE / InfiniBand (recommended):
+    
+    ```bash
+    $ mpirun -np 16 -x LD_LIBRARY_PATH -mca pml ob1 -mca btl_openib_receive_queues P,128,32:P,2048,32:P,12288,32:P,131072,32 -H server1:4,server2:4,server3:4,server4:4 python scripts/tf_cnn_benchmarks/tf_cnn_benchmarks.py --model resnet101 --batch_size 64 --variable_update horovod
+    ```
+
+4. At the end of the run, you will see number of images processed per second:
+
+```
+total images/sec: 1656.82
+```

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -22,17 +22,78 @@ $ git checkout horovod_v2
     1. If you have a plain TCP network:
     
     ```bash
-    $ mpirun -np 16 -bind-to none -oversubscribe -x LD_LIBRARY_PATH -H server1:4,server2:4,server3:4,server4:4 python scripts/tf_cnn_benchmarks/tf_cnn_benchmarks.py --model resnet101 --batch_size 64 --variable_update horovod
+    $ mpirun -np 16 \
+        -bind-to none -oversubscribe \
+        -x NCCL_DEBUG=INFO -x LD_LIBRARY_PATH \
+        -H server1:4,server2:4,server3:4,server4:4 \
+        \
+        python scripts/tf_cnn_benchmarks/tf_cnn_benchmarks.py \
+            --model resnet101 \
+            --batch_size 64 \
+            --variable_update horovod
     ```
 
     2. If you have a network with RoCE / InfiniBand (recommended):
     
     ```bash
-    $ mpirun -np 16 -bind-to none -oversubscribe -x LD_LIBRARY_PATH -mca pml ob1 -mca btl_openib_receive_queues P,128,32:P,2048,32:P,12288,32:P,65536,32 -H server1:4,server2:4,server3:4,server4:4 python scripts/tf_cnn_benchmarks/tf_cnn_benchmarks.py --model resnet101 --batch_size 64 --variable_update horovod
+    $ mpirun -np 16 \
+        -bind-to none -oversubscribe \
+        -x NCCL_DEBUG=INFO -x LD_LIBRARY_PATH \
+        -mca pml ob1 -mca btl_openib_receive_queues P,128,32:P,2048,32:P,12288,32:P,65536,32 \
+        -H server1:4,server2:4,server3:4,server4:4 \
+        \
+        python scripts/tf_cnn_benchmarks/tf_cnn_benchmarks.py \
+            --model resnet101 \
+            --batch_size 64 \
+            --variable_update horovod
     ```
 
 4. At the end of the run, you will see number of images processed per second:
 
 ```
 total images/sec: 1656.82
+```
+
+### Real data benchmarks
+
+The benchmark instructions above are for the synthetic data benchmark.
+
+In order to run the benchmark on a real data, you need to download [ImageNet dataset](http://image-net.org/download-images)
+and convert it using the TFRecord [preprocessing script](https://github.com/tensorflow/models/blob/master/research/inception/inception/data/download_and_preprocess_imagenet.sh).
+
+Now, simply add `--data_dir /path/to/imagenet/tfrecords --data_name imagenet --num_batches=2000` to your training command:
+
+1. If you have a plain TCP network:
+
+```bash
+$ mpirun -np 16 \
+    -bind-to none -oversubscribe \
+    -x NCCL_DEBUG=INFO -x LD_LIBRARY_PATH \
+    -H server1:4,server2:4,server3:4,server4:4 \
+    \
+    python scripts/tf_cnn_benchmarks/tf_cnn_benchmarks.py \
+        --model resnet101 \
+        --batch_size 64 \
+        --variable_update horovod \
+        --data_dir /path/to/imagenet/tfrecords \
+        --data_name imagenet \
+        --num_batches=2000
+```
+
+2. If you have a network with RoCE / InfiniBand (recommended):
+
+```bash
+$ mpirun -np 16 \
+    -bind-to none -oversubscribe \
+    -x NCCL_DEBUG=INFO -x LD_LIBRARY_PATH \
+    -mca pml ob1 -mca btl_openib_receive_queues P,128,32:P,2048,32:P,12288,32:P,65536,32 \
+    -H server1:4,server2:4,server3:4,server4:4 \
+    \
+    python scripts/tf_cnn_benchmarks/tf_cnn_benchmarks.py \
+        --model resnet101 \
+        --batch_size 64 \
+        --variable_update horovod \
+        --data_dir /path/to/imagenet/tfrecords \
+        --data_name imagenet \
+        --num_batches=2000
 ```

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -19,21 +19,7 @@ $ git checkout horovod_v2
 
 3. Run the benchmark. Examples below are for Open MPI.
 
-    1. If you have a plain TCP network:
-    
-    ```bash
-    $ mpirun -np 16 \
-        -bind-to none -oversubscribe \
-        -x NCCL_DEBUG=INFO -x LD_LIBRARY_PATH \
-        -H server1:4,server2:4,server3:4,server4:4 \
-        \
-        python scripts/tf_cnn_benchmarks/tf_cnn_benchmarks.py \
-            --model resnet101 \
-            --batch_size 64 \
-            --variable_update horovod
-    ```
-
-    2. If you have a network with RoCE / InfiniBand (recommended):
+    1. If you have a network with RoCE / InfiniBand (recommended):
     
     ```bash
     $ mpirun -np 16 \
@@ -48,7 +34,21 @@ $ git checkout horovod_v2
             --variable_update horovod
     ```
 
-4. At the end of the run, you will see number of images processed per second:
+    2. If you have a plain TCP network:
+    
+    ```bash
+    $ mpirun -np 16 \
+        -bind-to none -oversubscribe \
+        -x NCCL_DEBUG=INFO -x LD_LIBRARY_PATH \
+        -H server1:4,server2:4,server3:4,server4:4 \
+        \
+        python scripts/tf_cnn_benchmarks/tf_cnn_benchmarks.py \
+            --model resnet101 \
+            --batch_size 64 \
+            --variable_update horovod
+    ```
+
+4. At the end of the run, you will see the number of images processed per second:
 
 ```
 total images/sec: 1656.82
@@ -58,17 +58,18 @@ total images/sec: 1656.82
 
 The benchmark instructions above are for the synthetic data benchmark.
 
-In order to run the benchmark on a real data, you need to download [ImageNet dataset](http://image-net.org/download-images)
+To run the benchmark on a real data, you need to download the [ImageNet dataset](http://image-net.org/download-images)
 and convert it using the TFRecord [preprocessing script](https://github.com/tensorflow/models/blob/master/research/inception/inception/data/download_and_preprocess_imagenet.sh).
 
 Now, simply add `--data_dir /path/to/imagenet/tfrecords --data_name imagenet --num_batches=2000` to your training command:
 
-1. If you have a plain TCP network:
+1. If you have a network with RoCE / InfiniBand (recommended):
 
 ```bash
 $ mpirun -np 16 \
     -bind-to none -oversubscribe \
     -x NCCL_DEBUG=INFO -x LD_LIBRARY_PATH \
+    -mca pml ob1 -mca btl_openib_receive_queues P,128,32:P,2048,32:P,12288,32:P,65536,32 \
     -H server1:4,server2:4,server3:4,server4:4 \
     \
     python scripts/tf_cnn_benchmarks/tf_cnn_benchmarks.py \
@@ -80,13 +81,12 @@ $ mpirun -np 16 \
         --num_batches=2000
 ```
 
-2. If you have a network with RoCE / InfiniBand (recommended):
+2. If you have a plain TCP network:
 
 ```bash
 $ mpirun -np 16 \
     -bind-to none -oversubscribe \
     -x NCCL_DEBUG=INFO -x LD_LIBRARY_PATH \
-    -mca pml ob1 -mca btl_openib_receive_queues P,128,32:P,2048,32:P,12288,32:P,65536,32 \
     -H server1:4,server2:4,server3:4,server4:4 \
     \
     python scripts/tf_cnn_benchmarks/tf_cnn_benchmarks.py \

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -17,18 +17,18 @@ $ cd benchmarks
 $ git checkout horovod_v2
 ```
 
-3. Run the benchmark.
+3. Run the benchmark. Examples below are for Open MPI.
 
     1. If you have a plain TCP network:
     
     ```bash
-    $ mpirun -np 16 -x LD_LIBRARY_PATH -H server1:4,server2:4,server3:4,server4:4 python scripts/tf_cnn_benchmarks/tf_cnn_benchmarks.py --model resnet101 --batch_size 64 --variable_update horovod
+    $ mpirun -np 16 -bind-to none -oversubscribe -x LD_LIBRARY_PATH -H server1:4,server2:4,server3:4,server4:4 python scripts/tf_cnn_benchmarks/tf_cnn_benchmarks.py --model resnet101 --batch_size 64 --variable_update horovod
     ```
 
     2. If you have a network with RoCE / InfiniBand (recommended):
     
     ```bash
-    $ mpirun -np 16 -x LD_LIBRARY_PATH -mca pml ob1 -mca btl_openib_receive_queues P,128,32:P,2048,32:P,12288,32:P,131072,32 -H server1:4,server2:4,server3:4,server4:4 python scripts/tf_cnn_benchmarks/tf_cnn_benchmarks.py --model resnet101 --batch_size 64 --variable_update horovod
+    $ mpirun -np 16 -bind-to none -oversubscribe -x LD_LIBRARY_PATH -mca pml ob1 -mca btl_openib_receive_queues P,128,32:P,2048,32:P,12288,32:P,65536,32 -H server1:4,server2:4,server3:4,server4:4 python scripts/tf_cnn_benchmarks/tf_cnn_benchmarks.py --model resnet101 --batch_size 64 --variable_update horovod
     ```
 
 4. At the end of the run, you will see number of images processed per second:

--- a/docs/running.md
+++ b/docs/running.md
@@ -1,15 +1,15 @@
-## Running the Horovod
+## Running Horovod
 
-Examples below are for Open MPI. Check your MPI documentation for arguments to the `mpirun` command on your system.
+The examples below are for Open MPI. Check your MPI documentation for arguments to the `mpirun` command on your system.
 
-Typically, one GPU will be allocated per process, so if a server has 4 GPUs you would run 4 processes. In Open MPI,
-number of processes is specified with `-np` flag.
+Typically one GPU will be allocated per process, so if a server has 4 GPUs, you would run 4 processes. In Open MPI,
+the number of processes is specified with the `-np` flag.
 
-Starting with the Open MPI 3, it's important to add `-bind-to none` and `-oversubscribe` arguments. `-bind-to none`
+Starting with the Open MPI 3, it's important to add the `-bind-to none` and `-oversubscribe` arguments. `-bind-to none`
 specifies Open MPI to not bind a training process to a single CPU core (which would hurt performance). `-oversubscribe`
-allows to run multiple training processes on a single core.
+enables you to to run multiple training processes on a single core.
 
-The `-x` option allows to specify (`-x NCCL_DEBUG=INFO`) or copy (`-x LD_LIBRARY_PATH`) an environment variable to all
+With the `-x` option you can specify (`-x NCCL_DEBUG=INFO`) or copy (`-x LD_LIBRARY_PATH`) an environment variable to all
 the workers.
 
 1. To run on a machine with 4 GPUs:
@@ -31,7 +31,7 @@ $ mpirun -np 16 \
     python train.py
 ```
 
-3. If you have RoCE or InfiniBand, we found the following `pml` and `btl_openib_receive_queues` parameters to help
+3. If you have RoCE or InfiniBand, we found that the `pml` and `btl_openib_receive_queues` parameters improve
 performance a lot:
 
 ```bash
@@ -47,7 +47,7 @@ $ mpirun -np 16 \
 
 Having network interfaces that are not routed can cause Open MPI to hang. An example of such interface is `docker0`.
 
-If you see non-routed interfaces (like `docker0`) in the output of `ifconfig`, you should tell Open MPI to not used them
+If you see non-routed interfaces (like `docker0`) in the output of `ifconfig`, you should tell Open MPI to not use them
 via the `-mca btl_tcp_if_exclude <interface>[,<interface>]` parameter.
 
 ```bash

--- a/docs/running.md
+++ b/docs/running.md
@@ -1,0 +1,93 @@
+## Running the Horovod
+
+Examples below are for Open MPI. Check your MPI documentation for arguments to the `mpirun` command on your system.
+
+Typically, one GPU will be allocated per process, so if a server has 4 GPUs you would run 4 processes. In Open MPI,
+number of processes is specified with `-np` flag.
+
+Starting with the Open MPI 3, it's important to add `-bind-to none` and `-oversubscribe` arguments. `-bind-to none`
+specifies Open MPI to not bind a training process to a single CPU core (which would hurt performance). `-oversubscribe`
+allows to run multiple training processes on a single core.
+
+The `-x` option allows to specify (`-x NCCL_DEBUG=INFO`) or copy (`-x LD_LIBRARY_PATH`) an environment variable to all
+the workers.
+
+1. To run on a machine with 4 GPUs:
+
+```bash
+$ mpirun -np 4 \
+    -bind-to none -oversubscribe \
+    -x NCCL_DEBUG=INFO -x LD_LIBRARY_PATH \
+    python train.py
+```
+
+2. To run on 4 machines with 4 GPUs each:
+
+```bash
+$ mpirun -np 16 \
+    -bind-to none -oversubscribe \
+    -x NCCL_DEBUG=INFO -x LD_LIBRARY_PATH \
+    -H server1:4,server2:4,server3:4,server4:4 \
+    python train.py
+```
+
+3. If you have RoCE or InfiniBand, we found the following `pml` and `btl_openib_receive_queues` parameters to help
+performance a lot:
+
+```bash
+$ mpirun -np 16 \
+    -bind-to none -oversubscribe \
+    -x NCCL_DEBUG=INFO -x LD_LIBRARY_PATH \
+    -mca pml ob1 -mca btl_openib_receive_queues P,128,32:P,2048,32:P,12288,32:P,65536,32 \
+    -H server1:4,server2:4,server3:4,server4:4 \
+    python train.py
+```
+
+### Hangs due to non-routed network interfaces
+
+Having network interfaces that are not routed can cause Open MPI to hang. An example of such interface is `docker0`.
+
+If you see non-routed interfaces (like `docker0`) in the output of `ifconfig`, you should tell Open MPI to not used them
+via the `-mca btl_tcp_if_exclude <interface>[,<interface>]` parameter.
+
+```bash
+$ ifconfig
+docker0   Link encap:Ethernet  HWaddr 02:42:2d:17:ea:66
+          inet addr:172.17.0.1  Bcast:0.0.0.0  Mask:255.255.0.0
+          UP BROADCAST MULTICAST  MTU:1500  Metric:1
+          RX packets:0 errors:0 dropped:0 overruns:0 frame:0
+          TX packets:0 errors:0 dropped:0 overruns:0 carrier:0
+          collisions:0 txqueuelen:0
+          RX bytes:0 (0.0 B)  TX bytes:0 (0.0 B)
+
+eth0      Link encap:Ethernet  HWaddr 24:8a:07:b3:7d:8b
+          inet addr:10.0.0.1  Bcast:10.0.0.255  Mask:255.255.255.0
+          UP BROADCAST RUNNING MULTICAST  MTU:1500  Metric:1
+          RX packets:900002410 errors:0 dropped:405 overruns:0 frame:0
+          TX packets:1521598641 errors:0 dropped:0 overruns:0 carrier:0
+          collisions:0 txqueuelen:1000
+          RX bytes:376184431726 (350.3 GiB)  TX bytes:954933846124 (889.3 GiB)
+
+eth1      Link encap:Ethernet  HWaddr 24:8a:07:b3:7d:8a
+          inet addr:192.168.0.1  Bcast:192.168.0.255  Mask:255.255.255.0
+          UP BROADCAST RUNNING MULTICAST  MTU:1500  Metric:1
+          RX packets:2410141 errors:0 dropped:0 overruns:0 frame:0
+          TX packets:2312177 errors:0 dropped:0 overruns:0 carrier:0
+          collisions:0 txqueuelen:1000
+          RX bytes:698398061 (666.0 MiB)  TX bytes:458504418 (437.2 MiB)
+
+lo        Link encap:Local Loopback
+          inet addr:127.0.0.1  Mask:255.0.0.0
+          inet6 addr: ::1/128 Scope:Host
+          UP LOOPBACK RUNNING  MTU:65536  Metric:1
+          RX packets:497075633 errors:0 dropped:0 overruns:0 frame:0
+          TX packets:497075633 errors:0 dropped:0 overruns:0 carrier:0
+          collisions:0 txqueuelen:1
+          RX bytes:72680421398 (67.6 GiB)  TX bytes:72680421398 (67.6 GiB)
+```
+
+For example:
+
+```bash
+$ mpirun -mca btl_tcp_if_exclude docker0 -np 16 -bind-to none -oversubscribe -x LD_LIBRARY_PATH -H server1:4,server2:4,server3:4,server4:4 python train.py
+```


### PR DESCRIPTION
1. Open MPI 3 specific instructions.
2. Dealing with non-routed network interfaces.
3. Keras 2.0.9 bug.
4. `-mca pml ob1` to avoid UCX issues.
5. Benchmarking instructions.

Covers questions in #70, #67, #60.