### PR TITLE
Replace `-oversubscribe` with `-map-by slot`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,7 +68,7 @@ script:
   # run unit tests
   - |
     if [ $MPI == "OpenMPI" ]; then
-      mpirun -oversubscribe -allow-run-as-root -np 2 python horovod/tensorflow/mpi_ops_test.py
+      mpirun -allow-run-as-root -np 2 -H localhost:2 -bind-to none -map-by slot python horovod/tensorflow/mpi_ops_test.py
     else
       mpirun -np 2 python horovod/tensorflow/mpi_ops_test.py
     fi
@@ -76,7 +76,7 @@ script:
   # run TensorFlow MNIST example
   - |
     if [ $MPI == "OpenMPI" ]; then
-      mpirun -oversubscribe -allow-run-as-root -np 2 python examples/tensorflow_mnist.py
+      mpirun -allow-run-as-root -np 2 -H localhost:2 -bind-to none -map-by slot python examples/tensorflow_mnist.py
     else
       mpirun -np 2 python examples/tensorflow_mnist.py
     fi
@@ -92,7 +92,7 @@ script:
   # run Keras MNIST advanced example
   - |
     if [ $MPI == "OpenMPI" ]; then
-      mpirun -oversubscribe -allow-run-as-root -np 2 python examples/keras_mnist_advanced.py
+      mpirun -allow-run-as-root -np 2 -H localhost:2 -bind-to none -map-by slot python examples/keras_mnist_advanced.py
     else
       mpirun -np 2 python examples/keras_mnist_advanced.py
     fi

--- a/README.md
+++ b/README.md
@@ -126,7 +126,8 @@ page for more instructions, including RoCE/InfiniBand tweaks and tips for dealin
 
 ```bash
 $ mpirun -np 4 \
-    -bind-to none -oversubscribe \
+    -H localhost:4 \
+    -bind-to none -map-by slot \
     -x NCCL_DEBUG=INFO -x LD_LIBRARY_PATH \
     python train.py
 ```
@@ -135,9 +136,9 @@ $ mpirun -np 4 \
 
 ```bash
 $ mpirun -np 16 \
-    -bind-to none -oversubscribe \
-    -x NCCL_DEBUG=INFO -x LD_LIBRARY_PATH \
     -H server1:4,server2:4,server3:4,server4:4 \
+    -bind-to none -map-by slot \
+    -x NCCL_DEBUG=INFO -x LD_LIBRARY_PATH \
     python train.py
 ```
 

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -23,10 +23,10 @@ $ git checkout horovod_v2
     
     ```bash
     $ mpirun -np 16 \
-        -bind-to none -oversubscribe \
+        -H server1:4,server2:4,server3:4,server4:4 \
+        -bind-to none -map-by slot \
         -x NCCL_DEBUG=INFO -x LD_LIBRARY_PATH \
         -mca pml ob1 -mca btl_openib_receive_queues P,128,32:P,2048,32:P,12288,32:P,65536,32 \
-        -H server1:4,server2:4,server3:4,server4:4 \
         \
         python scripts/tf_cnn_benchmarks/tf_cnn_benchmarks.py \
             --model resnet101 \
@@ -38,9 +38,9 @@ $ git checkout horovod_v2
     
     ```bash
     $ mpirun -np 16 \
-        -bind-to none -oversubscribe \
-        -x NCCL_DEBUG=INFO -x LD_LIBRARY_PATH \
         -H server1:4,server2:4,server3:4,server4:4 \
+        -bind-to none -map-by slot \
+        -x NCCL_DEBUG=INFO -x LD_LIBRARY_PATH \
         \
         python scripts/tf_cnn_benchmarks/tf_cnn_benchmarks.py \
             --model resnet101 \
@@ -67,10 +67,10 @@ Now, simply add `--data_dir /path/to/imagenet/tfrecords --data_name imagenet --n
 
 ```bash
 $ mpirun -np 16 \
-    -bind-to none -oversubscribe \
+    -H server1:4,server2:4,server3:4,server4:4 \
+    -bind-to none -map-by slot \
     -x NCCL_DEBUG=INFO -x LD_LIBRARY_PATH \
     -mca pml ob1 -mca btl_openib_receive_queues P,128,32:P,2048,32:P,12288,32:P,65536,32 \
-    -H server1:4,server2:4,server3:4,server4:4 \
     \
     python scripts/tf_cnn_benchmarks/tf_cnn_benchmarks.py \
         --model resnet101 \
@@ -85,9 +85,9 @@ $ mpirun -np 16 \
 
 ```bash
 $ mpirun -np 16 \
-    -bind-to none -oversubscribe \
-    -x NCCL_DEBUG=INFO -x LD_LIBRARY_PATH \
     -H server1:4,server2:4,server3:4,server4:4 \
+    -bind-to none -map-by slot \
+    -x NCCL_DEBUG=INFO -x LD_LIBRARY_PATH \
     \
     python scripts/tf_cnn_benchmarks/tf_cnn_benchmarks.py \
         --model resnet101 \

--- a/docs/running.md
+++ b/docs/running.md
@@ -7,7 +7,7 @@ the number of processes is specified with the `-np` flag.
 
 Starting with the Open MPI 3, it's important to add the `-bind-to none` and `-map-by slot` arguments. `-bind-to none`
 specifies Open MPI to not bind a training process to a single CPU core (which would hurt performance). `-map-by slot`
-allows to have a mixture of different NUMA configurations since the default is to bind to the socket.
+allows you to have a mixture of different NUMA configurations because the default behavior is to bind to the socket.
 
 With the `-x` option you can specify (`-x NCCL_DEBUG=INFO`) or copy (`-x LD_LIBRARY_PATH`) an environment variable to all
 the workers.

--- a/docs/running.md
+++ b/docs/running.md
@@ -5,9 +5,9 @@ The examples below are for Open MPI. Check your MPI documentation for arguments 
 Typically one GPU will be allocated per process, so if a server has 4 GPUs, you would run 4 processes. In Open MPI,
 the number of processes is specified with the `-np` flag.
 
-Starting with the Open MPI 3, it's important to add the `-bind-to none` and `-oversubscribe` arguments. `-bind-to none`
-specifies Open MPI to not bind a training process to a single CPU core (which would hurt performance). `-oversubscribe`
-enables you to to run multiple training processes on a single core.
+Starting with the Open MPI 3, it's important to add the `-bind-to none` and `-map-by slot` arguments. `-bind-to none`
+specifies Open MPI to not bind a training process to a single CPU core (which would hurt performance). `-map-by slot`
+allows to have a mixture of different NUMA configurations since the default is to bind to the socket.
 
 With the `-x` option you can specify (`-x NCCL_DEBUG=INFO`) or copy (`-x LD_LIBRARY_PATH`) an environment variable to all
 the workers.
@@ -16,7 +16,8 @@ the workers.
 
 ```bash
 $ mpirun -np 4 \
-    -bind-to none -oversubscribe \
+    -H localhost:4 \
+    -bind-to none -map-by slot \
     -x NCCL_DEBUG=INFO -x LD_LIBRARY_PATH \
     python train.py
 ```
@@ -25,9 +26,9 @@ $ mpirun -np 4 \
 
 ```bash
 $ mpirun -np 16 \
-    -bind-to none -oversubscribe \
-    -x NCCL_DEBUG=INFO -x LD_LIBRARY_PATH \
     -H server1:4,server2:4,server3:4,server4:4 \
+    -bind-to none -map-by slot \
+    -x NCCL_DEBUG=INFO -x LD_LIBRARY_PATH \
     python train.py
 ```
 
@@ -36,10 +37,10 @@ performance a lot:
 
 ```bash
 $ mpirun -np 16 \
-    -bind-to none -oversubscribe \
+    -H server1:4,server2:4,server3:4,server4:4 \
+    -bind-to none -map-by slot \
     -x NCCL_DEBUG=INFO -x LD_LIBRARY_PATH \
     -mca pml ob1 -mca btl_openib_receive_queues P,128,32:P,2048,32:P,12288,32:P,65536,32 \
-    -H server1:4,server2:4,server3:4,server4:4 \
     python train.py
 ```
 
@@ -89,5 +90,10 @@ lo        Link encap:Local Loopback
 For example:
 
 ```bash
-$ mpirun -mca btl_tcp_if_exclude docker0 -np 16 -bind-to none -oversubscribe -x LD_LIBRARY_PATH -H server1:4,server2:4,server3:4,server4:4 python train.py
+$ mpirun -np 16 \
+    -H server1:4,server2:4,server3:4,server4:4 \
+    -bind-to none -map-by slot \
+    -x NCCL_DEBUG=INFO -x LD_LIBRARY_PATH \
+    -mca btl_tcp_if_exclude docker0 \ 
+    python train.py
 ```

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -201,7 +201,11 @@ For example:
 
 ```bash
 $ export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/nccl-<version>/lib
-$ mpirun -np 16 -x LD_LIBRARY_PATH -H server1:4,server2:4,server3:4,server4:4 python train.py
+$ mpirun -np 4 \
+    -H localhost:4 \
+    -bind-to none -map-by slot \
+    -x NCCL_DEBUG=INFO -x LD_LIBRARY_PATH \
+    python train.py
 ```
 
 ### Pip install: no such option: --no-cache-dir
@@ -245,7 +249,11 @@ For example:
 
 ```bash
 $ export NCCL_DEBUG=INFO
-$ mpirun -np 16 -x NCCL_DEBUG -H server1:4,server2:4,server3:4,server4:4 python train.py
+$ mpirun -np 4 \
+    -H localhost:4 \
+    -bind-to none -map-by slot \
+    -x NCCL_DEBUG=INFO -x LD_LIBRARY_PATH \
+    python train.py
 ```
 
 ### Running out of memory


### PR DESCRIPTION
Potentially solves #94 and solves an internal issue I had with Open MPI 3.0.0.