### PR TITLE
Dockerize Travis as TensorFlow will require new GLIBC

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,17 +4,36 @@ python:
   - "2.7"
   - "3.4"
   - "3.6"
+services:
+  - docker
 
 before_install:
-  - sudo apt-get -qq update
-
-  - if [[ $TRAVIS_PYTHON_VERSION == 2* ]]; then pip install --upgrade pip; fi
-  - if [[ $TRAVIS_PYTHON_VERSION == 3* ]]; then pip3 install --upgrade pip; fi
-
-  # upgrade numpy to make sure `import tensorflow` does not cause numpy version error
-  # RuntimeError: module compiled against API version 0xb but this version of numpy is 0xa
-  - if [[ $TRAVIS_PYTHON_VERSION == 2* ]]; then pip install -U numpy; fi
-  - if [[ $TRAVIS_PYTHON_VERSION == 3* ]]; then pip3 install -U numpy; fi
+  # force latest Debian for Python 3.6 and nightly TensorFlow which requires new glibc
+  - |
+    if [[ $TRAVIS_PYTHON_VERSION == "3.6" || $TF_PACKAGE == "tf-nightly" ]]; then
+      export DEBIAN=sid
+    else
+      export DEBIAN=jessie
+    fi
+  - docker pull debian:$DEBIAN
+  # run docker container for an hour
+  - docker run -v `pwd`:/horovod debian:$DEBIAN /bin/sh -c "sleep 3600" &
+  # wait for docker to start
+  - sleep 5
+  - export CONTAINER=$(docker ps -q | head -n 1)
+  - docker exec $CONTAINER /bin/sh -c "apt-get update -qq"
+  # install Python, if it's Python 3 - add symlink for `python`
+  - |
+    if [[ $TRAVIS_PYTHON_VERSION == 3* ]]; then
+      docker exec $CONTAINER /bin/sh -c "apt-get install -y python$TRAVIS_PYTHON_VERSION python3-pip"
+      docker exec $CONTAINER /bin/sh -c "pip3 install -U --force pip"
+      docker exec $CONTAINER /bin/sh -c "ln -s /usr/bin/python3 /usr/bin/python"
+    else
+      docker exec $CONTAINER /bin/sh -c "apt-get install -y python$TRAVIS_PYTHON_VERSION python-pip"
+      docker exec $CONTAINER /bin/sh -c "pip install -U --force pip"
+    fi
+  # install necessary network tools
+  - docker exec $CONTAINER /bin/sh -c "apt-get install -y wget openssh-client git"
 
 env:
   matrix:
@@ -30,69 +49,57 @@ matrix:
       env: TF_PACKAGE=tensorflow==1.1.0 KERAS_PACKAGE=keras==2.0.0 MPI=MPICH
     - python: "3.6"
       env: TF_PACKAGE=tensorflow==1.1.0 KERAS_PACKAGE=keras==2.0.0 MPI=MPICH
-    - python: "3.6"
+    - python: "3.4"
       env: TF_PACKAGE=tf-nightly KERAS_PACKAGE=git+https://github.com/fchollet/keras.git MPI=OpenMPI
 
 install:
   - |
-    if [ $MPI == "OpenMPI" ]; then
-      wget -O /tmp/openmpi-3.0.0-bin.tar.gz https://github.com/uber/horovod/files/1439728/openmpi-3.0.0-bin.tar.gz
-      pushd /usr/local && sudo tar -zxf /tmp/openmpi-3.0.0-bin.tar.gz && popd
-      export PATH=/usr/local/openmpi/bin:$PATH
+    if [[ $MPI == "OpenMPI" ]]; then
+      docker exec $CONTAINER /bin/sh -c "wget -O /tmp/openmpi-3.0.0-bin.tar.gz https://github.com/uber/horovod/files/1596799/openmpi-3.0.0-bin.tar.gz"
+      docker exec $CONTAINER /bin/sh -c "cd /usr/local && tar -zxf /tmp/openmpi-3.0.0-bin.tar.gz && ldconfig"
     else
       # installs mpich version 3.0.4
-      sudo apt-get install mpich
+      docker exec $CONTAINER /bin/sh -c "apt-get install -y mpich"
     fi
 
   # TensorFlow
-  - if [[ $TRAVIS_PYTHON_VERSION == 2* ]]; then pip install "$TF_PACKAGE"; fi
-  - if [[ $TRAVIS_PYTHON_VERSION == 3* ]]; then pip3 install "$TF_PACKAGE"; fi
+  - docker exec $CONTAINER /bin/sh -c "pip install $TF_PACKAGE"
 
   # Keras
-  - if [[ $TRAVIS_PYTHON_VERSION == 2* ]]; then pip install "$KERAS_PACKAGE"; fi
-  - if [[ $TRAVIS_PYTHON_VERSION == 3* ]]; then pip3 install "$KERAS_PACKAGE"; fi
+  - docker exec $CONTAINER /bin/sh -c "pip install $KERAS_PACKAGE"
 
   # h5py for Keras model saving
-  - if [[ $TRAVIS_PYTHON_VERSION == 2* ]]; then pip install h5py; fi
-  - if [[ $TRAVIS_PYTHON_VERSION == 3* ]]; then pip3 install h5py; fi
+  - docker exec $CONTAINER /bin/sh -c "pip install h5py"
 
   # scipy for Keras image preprocessing
-  - if [[ $TRAVIS_PYTHON_VERSION == 2* ]]; then pip install scipy; fi
-  - if [[ $TRAVIS_PYTHON_VERSION == 3* ]]; then pip3 install scipy; fi
+  - docker exec $CONTAINER /bin/sh -c "pip install scipy"
 
   # Horovod
-  - python setup.py sdist
-  - pip install -v dist/horovod-*.tar.gz
+  - docker exec $CONTAINER /bin/sh -c "cd /horovod && python setup.py sdist"
+  - docker exec $CONTAINER /bin/sh -c "pip install -v /horovod/dist/horovod-*.tar.gz"
 
 script:
-  # run unit tests
   - |
-    if [ $MPI == "OpenMPI" ]; then
-      mpirun -allow-run-as-root -np 2 -H localhost:2 -bind-to none -map-by slot python horovod/tensorflow/mpi_ops_test.py
+    if [[ $MPI == "OpenMPI" ]]; then
+      export MPIRUN="mpirun -allow-run-as-root -np 2 -H localhost:2 -bind-to none -map-by slot"
     else
-      mpirun -np 2 python horovod/tensorflow/mpi_ops_test.py
+      export MPIRUN="mpirun -np 2"
     fi
+  
+
+  # run unit tests
+  - docker exec $CONTAINER /bin/sh -c "$MPIRUN python /horovod/horovod/tensorflow/mpi_ops_test.py"
 
   # run TensorFlow MNIST example
-  - |
-    if [ $MPI == "OpenMPI" ]; then
-      mpirun -allow-run-as-root -np 2 -H localhost:2 -bind-to none -map-by slot python examples/tensorflow_mnist.py
-    else
-      mpirun -np 2 python examples/tensorflow_mnist.py
-    fi
+  - docker exec $CONTAINER /bin/sh -c "$MPIRUN python /horovod/examples/tensorflow_mnist.py"
 
   # download Keras MNIST dataset
-  - python -c "from keras.datasets import mnist; mnist.load_data()"
+  - docker exec $CONTAINER /bin/sh -c "python -c \"from keras.datasets import mnist; mnist.load_data()\""
 
   # hack Keras MNIST advanced example to be smaller
-  - sed -i "s/epochs = .*/epochs = 12/" examples/keras_mnist_advanced.py
-  - sed -i "s/model.add(Conv2D(32, kernel_size=(3, 3),/model.add(Conv2D(1, kernel_size=(3, 3),/" examples/keras_mnist_advanced.py
-  - sed -i "s/model.add(Conv2D(64, (3, 3), activation='relu'))//" examples/keras_mnist_advanced.py
+  - docker exec $CONTAINER /bin/sh -c "sed -i \"s/epochs = .*/epochs = 12/\" /horovod/examples/keras_mnist_advanced.py"
+  - docker exec $CONTAINER /bin/sh -c "sed -i \"s/model.add(Conv2D(32, kernel_size=(3, 3),/model.add(Conv2D(1, kernel_size=(3, 3),/\" /horovod/examples/keras_mnist_advanced.py"
+  - docker exec $CONTAINER /bin/sh -c "sed -i \"s/model.add(Conv2D(64, (3, 3), activation='relu'))//\" /horovod/examples/keras_mnist_advanced.py"
 
   # run Keras MNIST advanced example
-  - |
-    if [ $MPI == "OpenMPI" ]; then
-      mpirun -allow-run-as-root -np 2 -H localhost:2 -bind-to none -map-by slot python examples/keras_mnist_advanced.py
-    else
-      mpirun -np 2 python examples/keras_mnist_advanced.py
-    fi
+  - docker exec $CONTAINER /bin/sh -c "$MPIRUN python /horovod/examples/keras_mnist_advanced.py"


### PR DESCRIPTION
TensorFlow upgraded base image to Ubuntu 16 (https://github.com/tensorflow/tensorflow/issues/15777).  Travis CI does not support Ubuntu 16 (https://github.com/travis-ci/travis-ci/issues/5821), so we need to dockerize our tests.