### PR TITLE
Update BroadcastGlobalVariablesHook to create a new broadcast op when run on a new TF graph

### DIFF
--- a/horovod/tensorflow/__init__.py
+++ b/horovod/tensorflow/__init__.py
@@ -117,7 +117,7 @@ class BroadcastGlobalVariablesHook(tf.train.SessionRunHook):
         self.device = device
 
     def begin(self):
-        if not self.bcast_op:
+        if not self.bcast_op or self.bcast_op.graph != tf.get_default_graph():
             with tf.device(self.device):
                 self.bcast_op = broadcast_global_variables(self.root_rank)
 


### PR DESCRIPTION
# Summary
This PR updates `BroadcastGlobalVariablesHook` to create a new broadcast op each time the hook is run on a new graph.

# Why this change?
Certain TensorFlow APIs, e.g. [tf.estimator.train_and_evaluate](https://www.tensorflow.org/versions/master/api_docs/python/tf/estimator/train_and_evaluate), depend upon being able to instantiate hooks once and reuse them across different TensorFlow graphs/sessions. In these cases the [begin()](https://www.tensorflow.org/api_docs/python/tf/train/SessionRunHook#begin) method is expected to add ops to the current graph if needed. However, the current BroadcastGlobalVariablesHook only adds broadcast ops to the current graph at the time the hook is first run. As a result, [this fork of the MNIST estimator example](https://gist.github.com/smurching/bb703e024507dde065ea11289b36da29) using `tf.estimator.train_and_evaluate` fails since BroadcastGlobalVariablesHook() is reused across calls to `estimator.train` and `estimator.evaluate`. This PR remedies the issue by updating BroadcastGlobalVariablesHook to create a new broadcast_op each time the hook is run on a new graph.


