### PR TITLE
MPI request fusion

### DIFF
--- a/horovod/common/mpi_message.cc
+++ b/horovod/common/mpi_message.cc
@@ -113,9 +113,10 @@ void MPIRequest::add_tensor_shape(int64_t value) {
   tensor_shape_.push_back(value);
 }
 
-void MPIRequest::ParseFromString(MPIRequest& request,
-                                 const std::string& input) {
-  auto obj = flatbuffers::GetRoot<wire::MPIRequest>((uint8_t*)input.c_str());
+namespace {
+
+void MPIRequest_ParseFromWire(MPIRequest& request,
+                              const wire::MPIRequest* obj) {
   request.set_request_rank(obj->request_rank());
   request.set_request_type((MPIRequest::RequestType)obj->request_type());
   request.set_tensor_type((MPIDataType)obj->tensor_type());
@@ -126,8 +127,9 @@ void MPIRequest::ParseFromString(MPIRequest& request,
                                                 obj->tensor_shape()->end()));
 }
 
-void MPIRequest::SerializeToString(MPIRequest& request, std::string& output) {
-  flatbuffers::FlatBufferBuilder builder(1024);
+void MPIRequest_SerializeToWire(const MPIRequest& request,
+                                flatbuffers::FlatBufferBuilder& builder,
+                                flatbuffers::Offset<wire::MPIRequest>& obj) {
   wire::MPIRequestBuilder request_builder(builder);
   request_builder.add_request_rank(request.request_rank());
   request_builder.add_request_type(
@@ -138,7 +140,64 @@ void MPIRequest::SerializeToString(MPIRequest& request, std::string& output) {
   request_builder.add_device(request.device());
   request_builder.add_tensor_shape(
       builder.CreateVector(request.tensor_shape()));
-  auto obj = request_builder.Finish();
+  obj = request_builder.Finish();
+}
+
+} // namespace
+
+void MPIRequest::ParseFromString(MPIRequest& request,
+                                 const std::string& input) {
+  auto obj = flatbuffers::GetRoot<wire::MPIRequest>((uint8_t*)input.c_str());
+  MPIRequest_ParseFromWire(request, obj);
+}
+
+void MPIRequest::SerializeToString(MPIRequest& request, std::string& output) {
+  flatbuffers::FlatBufferBuilder builder(1024);
+  flatbuffers::Offset<wire::MPIRequest> obj;
+  MPIRequest_SerializeToWire(request, builder, obj);
+  builder.Finish(obj);
+
+  uint8_t* buf = builder.GetBufferPointer();
+  auto size = builder.GetSize();
+  output = std::string((char*)buf, size);
+}
+
+const std::vector<MPIRequest>& MPIRequestList::requests() const {
+  return requests_;
+}
+
+void MPIRequestList::set_requests(const std::vector<MPIRequest>& value) {
+  requests_ = value;
+}
+
+void MPIRequestList::add_requests(MPIRequest value) {
+  requests_.push_back(value);
+}
+
+void MPIRequestList::ParseFromString(MPIRequestList& request_list,
+                                     const std::string& input) {
+  auto obj =
+      flatbuffers::GetRoot<wire::MPIRequestList>((uint8_t*)input.c_str());
+  for (auto it = obj->requests()->begin(); it != obj->requests()->end(); it++) {
+    MPIRequest request;
+    MPIRequest_ParseFromWire(request, *it);
+    request_list.add_requests(std::move(request));
+  }
+}
+
+void MPIRequestList::SerializeToString(MPIRequestList& request_list,
+                                       std::string& output) {
+  flatbuffers::FlatBufferBuilder builder(1024);
+  wire::MPIRequestListBuilder request_list_builder(builder);
+  std::vector<flatbuffers::Offset<wire::MPIRequest>> requests;
+  for (auto it = request_list.requests().begin();
+       it != request_list.requests().end(); it++) {
+    flatbuffers::Offset<wire::MPIRequest> req_obj;
+    MPIRequest_SerializeToWire(*it, builder, req_obj);
+    requests.push_back(req_obj);
+  }
+  request_list_builder.add_requests(builder.CreateVector(requests));
+  auto obj = request_list_builder.Finish();
   builder.Finish(obj);
 
   uint8_t* buf = builder.GetBufferPointer();

--- a/horovod/common/mpi_message.h
+++ b/horovod/common/mpi_message.h
@@ -84,6 +84,21 @@ private:
   std::vector<int64_t> tensor_shape_;
 };
 
+class MPIRequestList {
+public:
+  const std::vector<MPIRequest>& requests() const;
+  void set_requests(const std::vector<MPIRequest>& value);
+  void add_requests(MPIRequest value);
+
+  static void ParseFromString(MPIRequestList& request_list,
+                              const std::string& input);
+  static void SerializeToString(MPIRequestList& request_list,
+                                std::string& output);
+
+private:
+  std::vector<MPIRequest> requests_;
+};
+
 // An MPIResponse is a message sent from the coordinator (rank zero) to a rank
 // greater than zero, informing the rank of an operation should be performed
 // now. If the operation requested would result in an error (for example, due

--- a/horovod/common/wire/mpi_message.fbs
+++ b/horovod/common/wire/mpi_message.fbs
@@ -56,6 +56,9 @@ table MPIRequest {
     // to TensorFlow protos causes issues. See the comment for MPIDataType.
     tensor_shape:[long];
 }
+table MPIRequestList {
+    requests:[MPIRequest];
+}
 
 // An MPIResponse is a message sent from the coordinator (rank zero) to a rank
 // greater than zero, informing the rank of an operation should be performed


### PR DESCRIPTION
Fuse all available MPI requests together into a single request to save total # of MPI communications.  Improves performance on a very large scale (512+ GPUs).