### PR TITLE
Support for not calling MPI_Init_thread()/MPI_Finalize() in Horovod lifecycle

### DIFF
--- a/horovod/common/__init__.py
+++ b/horovod/common/__init__.py
@@ -37,10 +37,10 @@ MPI_COMMON_LIB_CTYPES = \
                              'mpi_lib' + get_ext_suffix()), mode=ctypes.RTLD_GLOBAL)
 
 
-def init(auto_mpi_init=True ,auto_mpi_finalize=True):
+def init(mpi_init=True ,mpi_finalize=True):
     """A function that initializes Horovod.
     """
-    return MPI_COMMON_LIB_CTYPES.horovod_init(ctypes.c_int(auto_mpi_init),ctypes.c_int(auto_mpi_finalize))
+    return MPI_COMMON_LIB_CTYPES.horovod_init(ctypes.c_bool(mpi_init),ctypes.c_bool(mpi_finalize))
 
 def close():  
     """A function that initializes Horovod.

--- a/horovod/common/__init__.py
+++ b/horovod/common/__init__.py
@@ -17,6 +17,7 @@
 import ctypes
 import os
 import sysconfig
+import atexit
 
 
 def get_ext_suffix():
@@ -42,11 +43,12 @@ def init(mpi_init=True ,mpi_finalize=True):
     """
     return MPI_COMMON_LIB_CTYPES.horovod_init(ctypes.c_bool(mpi_init),ctypes.c_bool(mpi_finalize))
 
-def close():  
-    """A function that initializes Horovod.
+def _close():  
+    """A function used by horovod to close Horovod during normal interpreter termination.
     """
     return MPI_COMMON_LIB_CTYPES.horovod_close()
 
+atexit.register(close)
 
 def size():
     """A function that returns the number of Horovod processes.

--- a/horovod/common/__init__.py
+++ b/horovod/common/__init__.py
@@ -37,10 +37,15 @@ MPI_COMMON_LIB_CTYPES = \
                              'mpi_lib' + get_ext_suffix()), mode=ctypes.RTLD_GLOBAL)
 
 
-def init():
+def init(auto_mpi_init=True ,auto_mpi_finalize=True):
     """A function that initializes Horovod.
     """
-    return MPI_COMMON_LIB_CTYPES.horovod_init()
+    return MPI_COMMON_LIB_CTYPES.horovod_init(ctypes.c_int(auto_mpi_init),ctypes.c_int(auto_mpi_finalize))
+
+def close():  
+    """A function that initializes Horovod.
+    """
+    return MPI_COMMON_LIB_CTYPES.horovod_close()
 
 
 def size():

--- a/horovod/common/__init__.py
+++ b/horovod/common/__init__.py
@@ -48,7 +48,7 @@ def _close():
     """
     return MPI_COMMON_LIB_CTYPES.horovod_close()
 
-atexit.register(close)
+atexit.register(_close)
 
 def size():
     """A function that returns the number of Horovod processes.

--- a/horovod/common/__init__.py
+++ b/horovod/common/__init__.py
@@ -38,17 +38,20 @@ MPI_COMMON_LIB_CTYPES = \
                              'mpi_lib' + get_ext_suffix()), mode=ctypes.RTLD_GLOBAL)
 
 
-def init(mpi_init=True ,mpi_finalize=True):
+def init(mpi_init=True, mpi_finalize=True):
     """A function that initializes Horovod.
+        mpi_init : if True, Automatic MPI initialization will be done by horovod at import (default: True).
+        mpi_finalize : if True, Automatic MPI finalization will be done by horovod at exit(default: True).
     """
-    return MPI_COMMON_LIB_CTYPES.horovod_init(ctypes.c_bool(mpi_init),ctypes.c_bool(mpi_finalize))
+    atexit.register(finalize)
+    return MPI_COMMON_LIB_CTYPES.horovod_init(ctypes.c_bool(mpi_init), ctypes.c_bool(mpi_finalize))
 
-def _close():  
-    """A function used by horovod to close Horovod during normal interpreter termination.
+
+def finalize():
+    """A function that will close Horovod and .
     """
-    return MPI_COMMON_LIB_CTYPES.horovod_close()
+    return MPI_COMMON_LIB_CTYPES.horovod_finalize()
 
-atexit.register(_close)
 
 def size():
     """A function that returns the number of Horovod processes.

--- a/horovod/common/operations.cc
+++ b/horovod/common/operations.cc
@@ -1171,6 +1171,7 @@ void BackgroundThreadLoop(HorovodGlobalState& state) {
   // be used together with Horovod if multi-threaded MPI is installed.
   int provided;
 
+  // Calls MPI_Init if horovod_global.auto_mpi_init is set otherwise prints warning
   if(horovod_global.auto_mpi_init){
     int is_mpi_initialized= 0;
     MPI_Initialized(&is_mpi_initialized);
@@ -1481,7 +1482,11 @@ void BackgroundThreadLoop(HorovodGlobalState& state) {
     (*it)(SHUT_DOWN_ERROR);
   }
 
-  while(true){
+  // Calls MPI_Finalize if horovod_global.auto_mpi_finalize is set otherwise prints warning
+  if(!horovod_global.auto_mpi_finalize){
+    std::cerr << "WARNING: Make sure to call MPI_Finalize." << std::endl
+  }
+  while(true){ 
     if(horovod_global.auto_mpi_finalize){
       int is_mpi_finalized = 0;
       MPI_Finalized(&is_mpi_finalized);

--- a/horovod/common/operations.h
+++ b/horovod/common/operations.h
@@ -39,7 +39,9 @@ extern "C" {
 // C interface to initialize Horovod.
 void horovod_init(bool auto_mpi_init_flag,bool auto_mpi_finalize_flag);
 
-// C interface to close Horovod.
+// Closes horovod if auto_mpi_finalize=False. This make sure horovod thread do not 
+// call MPI_Finalize while other MPI threads still running and vice versa.
+// if auto_mpi_finalize=true, this function has no effect
 int horovod_close();
 
 // C interface to get index of current Horovod process.

--- a/horovod/common/operations.h
+++ b/horovod/common/operations.h
@@ -37,7 +37,10 @@ Status CheckInitialized();
 extern "C" {
 
 // C interface to initialize Horovod.
-void horovod_init();
+void horovod_init(bool auto_mpi_init_flag,bool auto_mpi_finalize_flag);
+
+// C interface to close Horovod.
+int horovod_close();
 
 // C interface to get index of current Horovod process.
 // Returns -1 if Horovod is not initialized.

--- a/horovod/common/operations.h
+++ b/horovod/common/operations.h
@@ -37,12 +37,11 @@ Status CheckInitialized();
 extern "C" {
 
 // C interface to initialize Horovod.
-void horovod_init(bool auto_mpi_init_flag,bool auto_mpi_finalize_flag);
+void horovod_init(bool auto_mpi_init_flag, bool auto_mpi_finalize_flag);
 
-// Closes horovod if auto_mpi_finalize=False. This make sure horovod thread do not 
-// call MPI_Finalize while other MPI threads still running and vice versa.
-// if auto_mpi_finalize=true, this function has no effect
-int horovod_close();
+// Finalize horovod if auto_mpi_finalize=False. This will shutdown
+// the horovod thread after processing remaining messages
+int horovod_finalize();
 
 // C interface to get index of current Horovod process.
 // Returns -1 if Horovod is not initialized.

--- a/horovod/tensorflow/__init__.py
+++ b/horovod/tensorflow/__init__.py
@@ -32,7 +32,6 @@ from __future__ import print_function
 import tensorflow as tf
 
 from horovod.common import init
-from horovod.common import close
 from horovod.common import size
 from horovod.common import local_size
 from horovod.common import rank

--- a/horovod/tensorflow/__init__.py
+++ b/horovod/tensorflow/__init__.py
@@ -32,6 +32,7 @@ from __future__ import print_function
 import tensorflow as tf
 
 from horovod.common import init
+from horovod.common import finalize
 from horovod.common import size
 from horovod.common import local_size
 from horovod.common import rank
@@ -132,7 +133,7 @@ class DistributedOptimizer(tf.train.Optimizer):
     average gradient values before applying gradients to model weights."""
 
     def __init__(self, optimizer, name=None, use_locking=False, device_dense='',
-                 device_sparse=''):
+                device_sparse=''):
         """Construct a new DistributedOptimizer, which uses another optimizer
         under the hood for computing single-process gradient values and
         applying gradient updates after the gradient values have been averaged

--- a/horovod/tensorflow/__init__.py
+++ b/horovod/tensorflow/__init__.py
@@ -32,6 +32,7 @@ from __future__ import print_function
 import tensorflow as tf
 
 from horovod.common import init
+from horovod.common import close
 from horovod.common import size
 from horovod.common import local_size
 from horovod.common import rank

--- a/horovod/tensorflow/__init__.py
+++ b/horovod/tensorflow/__init__.py
@@ -133,7 +133,7 @@ class DistributedOptimizer(tf.train.Optimizer):
     average gradient values before applying gradients to model weights."""
 
     def __init__(self, optimizer, name=None, use_locking=False, device_dense='',
-                device_sparse=''):
+                 device_sparse=''):
         """Construct a new DistributedOptimizer, which uses another optimizer
         under the hood for computing single-process gradient values and
         applying gradient updates after the gradient values have been averaged


### PR DESCRIPTION
enhancement #216 and fix for potential bug due to this enhancement. 

import all module after disabling MPI.Init and MPI.Finalize and 
   i)hvd.init(mpi_init=True, mpi_finalize=False) (run_1.py)
        or 
   ii) calling MPI.Init (run_2.py) 

New function:
hvd.close()

closes horovod if mpi_finalize=False. Provides mechanism to make sure that horovod thread will not 
call MPI_Finalize while other MPI threads still running.
if mpi_finalize=true, this function has no effect