### PR TITLE
add horovod helm chart support

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ $ mpirun -np 16 \
 
 3. To run in Docker, see the [Horovod in Docker](docs/docker.md) page.
 
-4. To run in Kubernetes, see [Kubeflow](https://github.com/kubeflow/kubeflow/blob/master/kubeflow/openmpi/README.md).
+4. To run in Kubernetes, see [Kubeflow](https://github.com/kubeflow/kubeflow/blob/master/kubeflow/openmpi/README.md). Besides this, you can also try [Helm Chart](https://github.com/kubernetes/charts/tree/master/stable/horovod) solution.
 
 ## Keras
 


### PR DESCRIPTION
Hello,

I'm the author of [horovod helm chart](https://github.com/kubernetes/charts/tree/master/stable/horovod).  The horovod helm chart can deploy official horovod docker image with following features:

1. support official horovod docker image : uber/horovod:0.12.1-tf1.8.0-py3.5
2. support both host network and overlay network
3. customize the ssh port for  MPI connection without changing the docker image.

For more details, please read the [README](https://github.com/kubernetes/charts/blob/master/stable/horovod/README.md). I wish you can try this solution and give feedback to me. Thanks.
