### PR TITLE
Made synchronous pure functional Horovod ops differentiable in PyTorch

### DIFF
--- a/examples/pytorch_mnist.py
+++ b/examples/pytorch_mnist.py
@@ -119,7 +119,7 @@ def train(epoch):
 def metric_average(val, name):
     tensor = torch.FloatTensor([val])
     avg_tensor = hvd.allreduce(tensor, name=name)
-    return avg_tensor[0]
+    return avg_tensor.data[0]
 
 
 def test():

--- a/horovod/torch/mpi_ops.py
+++ b/horovod/torch/mpi_ops.py
@@ -22,6 +22,7 @@ import torch
 
 from horovod.torch import mpi_lib_impl
 from horovod.torch import mpi_lib
+from horovod.torch import rank, size
 
 
 # Schema: handle -> input, output
@@ -79,6 +80,18 @@ def allreduce_async(tensor, average=True, name=None):
     return _allreduce_async(tensor, output, average, name)
 
 
+class HorovodAllreduce(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, tensor, average, name):
+        ctx.average = average
+        handle = allreduce_async(tensor, average, name)
+        return synchronize(handle)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        return allreduce(grad_output, ctx.average), None, None
+
+
 def allreduce(tensor, average=True, name=None):
     """
     A function that performs averaging or summation of the input tensor over all the
@@ -99,8 +112,7 @@ def allreduce(tensor, average=True, name=None):
         A tensor of the same shape and type as `tensor`, averaged or summed across all
         processes.
     """
-    handle = allreduce_async(tensor, average, name)
-    return synchronize(handle)
+    return HorovodAllreduce.apply(tensor, average, name)
 
 
 def allreduce_async_(tensor, average=True, name=None):
@@ -183,6 +195,25 @@ def allgather_async(tensor, name=None):
     return _allgather_async(tensor, output, name)
 
 
+class HorovodAllgather(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, tensor, name):
+        ctx.dim = tensor.shape[0]
+        handle = allgather_async(tensor, name)
+        return synchronize(handle)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        grad_reduced = allreduce(grad_output, average=False)
+
+        dim_t = torch.tensor([ctx.dim])
+        dim = allgather(dim_t).view(size())
+
+        r = rank()
+        offset = torch.sum(dim.narrow(0, 0, r)).item() if r != 0 else 0
+        return grad_reduced.narrow(0, offset, ctx.dim), None
+
+
 def allgather(tensor, name=None):
     """
     A function that concatenates the input tensor with the same input tensor on
@@ -202,8 +233,7 @@ def allgather(tensor, name=None):
         the first dimension, which may be greater and is the sum of all first
         dimensions of the tensors in different Horovod processes.
     """
-    handle = allgather_async(tensor, name)
-    return synchronize(handle)
+    return HorovodAllgather.apply(tensor, name)
 
 
 def _broadcast_function_factory(tensor):
@@ -241,6 +271,21 @@ def broadcast_async(tensor, root_rank, name=None):
     return _broadcast_async(tensor, output, root_rank, name)
 
 
+class HorovodBroadcast(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, tensor, root_rank, name):
+        ctx.root_rank = root_rank
+        handle = broadcast_async(tensor, root_rank, name)
+        return synchronize(handle)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        grad_reduced = allreduce(grad_output, average=False)
+        if rank() != ctx.root_rank:
+            grad_reduced *= 0
+        return grad_reduced, None, None
+
+
 def broadcast(tensor, root_rank, name=None):
     """
     A function that broadcasts the input tensor on root rank to the same input tensor
@@ -260,8 +305,7 @@ def broadcast(tensor, root_rank, name=None):
         A tensor of the same shape and type as `tensor`, with the value broadcasted
         from root rank.
     """
-    handle = broadcast_async(tensor, root_rank, name)
-    return synchronize(handle)
+    return HorovodBroadcast.apply(tensor, root_rank, name)
 
 
 def broadcast_async_(tensor, root_rank, name=None):

--- a/horovod/torch/mpi_ops.py
+++ b/horovod/torch/mpi_ops.py
@@ -214,11 +214,11 @@ class HorovodAllgather(torch.autograd.Function):
     def backward(ctx, grad_output):
         grad_reduced = allreduce(grad_output, average=False)
 
-        dim_t = torch.tensor([ctx.dim])
+        dim_t = torch.IntTensor([ctx.dim])
         dim = allgather(dim_t).view(size())
 
         r = rank()
-        offset = torch.sum(dim.narrow(0, 0, r)).item() if r != 0 else 0
+        offset = torch.sum(dim.narrow(0, 0, r)).data[0] if r != 0 else 0
         return grad_reduced.narrow(0, offset, ctx.dim), None
 
 

--- a/horovod/torch/mpi_ops.py
+++ b/horovod/torch/mpi_ops.py
@@ -81,6 +81,8 @@ def allreduce_async(tensor, average=True, name=None):
 
 
 class HorovodAllreduce(torch.autograd.Function):
+    """An autograd function that performs allreduce on a tensor."""
+
     @staticmethod
     def forward(ctx, tensor, average, name):
         ctx.average = average
@@ -101,6 +103,10 @@ def allreduce(tensor, average=True, name=None):
     auto-generated name is used. The tensor type and shape must be the same on all
     Horovod processes for a given name. The reduction will not start until all processes
     are ready to send and receive the tensor.
+
+    This acts as a thin wrapper around an autograd function.  If your input
+    tensor requires gradients, then callings this function will allow gradients
+    to be computed and backpropagated.
 
     Arguments:
         tensor: A tensor to average and sum.
@@ -196,6 +202,8 @@ def allgather_async(tensor, name=None):
 
 
 class HorovodAllgather(torch.autograd.Function):
+    """An autograd function that performs allgather on a tensor."""
+
     @staticmethod
     def forward(ctx, tensor, name):
         ctx.dim = tensor.shape[0]
@@ -222,6 +230,10 @@ def allgather(tensor, name=None):
     The concatenation is done on the first dimension, so the input tensors on the
     different processes must have the same rank and shape, except for the first
     dimension, which is allowed to be different.
+
+    This acts as a thin wrapper around an autograd function.  If your input
+    tensor requires gradients, then callings this function will allow gradients
+    to be computed and backpropagated.
 
     Arguments:
         tensor: A tensor to allgather.
@@ -272,6 +284,8 @@ def broadcast_async(tensor, root_rank, name=None):
 
 
 class HorovodBroadcast(torch.autograd.Function):
+    """An autograd function that broadcasts a tensor."""
+
     @staticmethod
     def forward(ctx, tensor, root_rank, name):
         ctx.root_rank = root_rank
@@ -295,6 +309,10 @@ def broadcast(tensor, root_rank, name=None):
     auto-generated name is used. The tensor type and shape must be the same on all
     Horovod processes for a given name. The broadcast will not start until all processes
     are ready to send and receive the tensor.
+
+    This acts as a thin wrapper around an autograd function.  If your input
+    tensor requires gradients, then callings this function will allow gradients
+    to be computed and backpropagated.
 
     Arguments:
         tensor: A tensor to broadcast.

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -19,515 +19,634 @@ from __future__ import print_function
 
 import itertools
 import torch
+import unittest
+import numpy as np
 
 import horovod.torch as hvd
 
 
-def test_horovod_allreduce():
-    """Test that the allreduce correctly sums 1D, 2D, 3D tensors."""
-    hvd.init()
-    size = hvd.size()
-    dtypes = [torch.IntTensor, torch.LongTensor,
-              torch.FloatTensor, torch.DoubleTensor]
-    if torch.cuda.is_available():
-        dtypes += [torch.cuda.IntTensor, torch.cuda.LongTensor,
-                   torch.cuda.FloatTensor, torch.cuda.DoubleTensor]
-    dims = [1, 2, 3]
-    for dtype, dim in itertools.product(dtypes, dims):
+class TorchTests(unittest.TestCase):
+    """
+    Tests for ops in horovod.torch.
+    """
+
+    def test_horovod_allreduce(self):
+        """Test that the allreduce correctly sums 1D, 2D, 3D tensors."""
+        hvd.init()
+        size = hvd.size()
+        dtypes = [torch.IntTensor, torch.LongTensor,
+                  torch.FloatTensor, torch.DoubleTensor]
+        if torch.cuda.is_available():
+            dtypes += [torch.cuda.IntTensor, torch.cuda.LongTensor,
+                       torch.cuda.FloatTensor, torch.cuda.DoubleTensor]
+        dims = [1, 2, 3]
+        for dtype, dim in itertools.product(dtypes, dims):
+            torch.manual_seed(1234)
+            tensor = torch.FloatTensor(*([17] * dim)).random_(-100, 100)
+            tensor = tensor.type(dtype)
+            summed = hvd.allreduce(tensor, average=False)
+            multiplied = tensor * size
+            max_difference = summed.sub(multiplied).max()
+
+            # Threshold for floating point equality depends on number of
+            # ranks, since we're comparing against precise multiplication.
+            if size <= 3 or dtype in [torch.IntTensor, torch.LongTensor,
+                                      torch.cuda.IntTensor, torch.cuda.LongTensor]:
+                threshold = 0
+            elif size < 10:
+                threshold = 1e-4
+            elif size < 15:
+                threshold = 5e-4
+            else:
+                break
+
+            assert max_difference <= threshold, 'hvd.allreduce produces incorrect results'
+
+    def test_horovod_allreduce_average(self):
+        """Test that the allreduce correctly sums 1D, 2D, 3D tensors."""
+        hvd.init()
+        size = hvd.size()
+        dtypes = [torch.IntTensor, torch.LongTensor,
+                  torch.FloatTensor, torch.DoubleTensor]
+        if torch.cuda.is_available():
+            dtypes += [torch.cuda.IntTensor, torch.cuda.LongTensor,
+                       torch.cuda.FloatTensor, torch.cuda.DoubleTensor]
+        dims = [1, 2, 3]
+        for dtype, dim in itertools.product(dtypes, dims):
+            torch.manual_seed(1234)
+            tensor = torch.FloatTensor(*([17] * dim)).random_(-100, 100)
+            tensor = tensor.type(dtype)
+            averaged = hvd.allreduce(tensor, average=True)
+            max_difference = averaged.sub(tensor).max()
+
+            # Threshold for floating point equality depends on number of
+            # ranks, since we're comparing against precise multiplication.
+            if size <= 3 or dtype in [torch.IntTensor, torch.LongTensor,
+                                      torch.cuda.IntTensor, torch.cuda.LongTensor]:
+                threshold = 0
+            elif size < 10:
+                threshold = 1e-4
+            elif size < 15:
+                threshold = 5e-4
+            else:
+                break
+
+            assert max_difference <= threshold, 'hvd.allreduce produces incorrect results'
+
+    def test_horovod_allreduce_inplace(self):
+        """Test that the allreduce correctly sums 1D, 2D, 3D tensors."""
+        hvd.init()
+        size = hvd.size()
+        dtypes = [torch.IntTensor, torch.LongTensor,
+                  torch.FloatTensor, torch.DoubleTensor]
+        if torch.cuda.is_available():
+            dtypes += [torch.cuda.IntTensor, torch.cuda.LongTensor,
+                       torch.cuda.FloatTensor, torch.cuda.DoubleTensor]
+        dims = [1, 2, 3]
+        for dtype, dim in itertools.product(dtypes, dims):
+            torch.manual_seed(1234)
+            tensor = torch.FloatTensor(*([17] * dim)).random_(-100, 100)
+            tensor = tensor.type(dtype)
+            multiplied = tensor * size
+            hvd.allreduce_(tensor, average=False)
+            max_difference = tensor.sub(multiplied).max()
+
+            # Threshold for floating point equality depends on number of
+            # ranks, since we're comparing against precise multiplication.
+            if size <= 3 or dtype in [torch.IntTensor, torch.LongTensor,
+                                      torch.cuda.IntTensor, torch.cuda.LongTensor]:
+                threshold = 0
+            elif size < 10:
+                threshold = 1e-4
+            elif size < 15:
+                threshold = 5e-4
+            else:
+                break
+
+            assert max_difference <= threshold, 'hvd.allreduce produces incorrect results'
+
+    def test_horovod_allreduce_async_fused(self):
+        """Test that the allreduce correctly sums 1D, 2D, 3D tensors
+        with Tensor Fusion."""
+        hvd.init()
+        size = hvd.size()
+        dtypes = [torch.IntTensor, torch.LongTensor,
+                  torch.FloatTensor, torch.DoubleTensor]
+        if torch.cuda.is_available():
+            dtypes += [torch.cuda.IntTensor, torch.cuda.LongTensor,
+                       torch.cuda.FloatTensor, torch.cuda.DoubleTensor]
+        dims = [1, 2, 3]
+        tests = []
+        is_hvd_poll_false_once = False
+        for dtype, dim in itertools.product(dtypes, dims):
+            torch.manual_seed(1234)
+            tensor = torch.FloatTensor(*([17] * dim)).random_(-100, 100)
+            tensor = tensor.type(dtype)
+            handle = hvd.allreduce_async(tensor, average=False)
+            if not hvd.poll(handle):
+                is_hvd_poll_false_once = True
+            multiplied = tensor * size
+            tests.append((dtype, multiplied, handle))
+
+        # Make sure it's an asynchronous operation.
+        assert is_hvd_poll_false_once, 'hvd.poll() always returns True, not an async op?'
+
+        for dtype, multiplied, handle in tests:
+            summed = hvd.synchronize(handle)
+            max_difference = summed.sub(multiplied).max()
+
+            # Threshold for floating point equality depends on number of
+            # ranks, since we're comparing against precise multiplication.
+            if size <= 3 or dtype in [torch.IntTensor, torch.LongTensor,
+                                      torch.cuda.IntTensor, torch.cuda.LongTensor]:
+                threshold = 0
+            elif size < 10:
+                threshold = 1e-4
+            elif size < 15:
+                threshold = 5e-4
+            else:
+                break
+
+            assert max_difference <= threshold, 'hvd.allreduce produces incorrect results'
+
+    def test_horovod_allreduce_multi_gpu(self):
+        """Test that the allreduce works on multiple GPUs."""
+        # Only do this test if there are GPUs available.
+        if not torch.cuda.is_available():
+            return
+
+        hvd.init()
+        local_rank = hvd.local_rank()
+        size = hvd.size()
+
+        iter = 0
+        dtypes = [torch.cuda.IntTensor, torch.cuda.LongTensor,
+                  torch.cuda.FloatTensor, torch.cuda.DoubleTensor]
+        dims = [1, 2, 3]
+        for dtype, dim in itertools.product(dtypes, dims):
+            iter += 1
+            torch.manual_seed(1234)
+            tensor = torch.FloatTensor(*([17] * dim)).random_(-100, 100)
+            device = local_rank * 2 + (iter + local_rank) % 2
+            tensor = tensor.cuda(device).type(dtype)
+            multiplied = tensor * size
+            hvd.allreduce_(tensor, average=False)
+            max_difference = tensor.sub(multiplied).max()
+
+            # Threshold for floating point equality depends on number of
+            # ranks, since we're comparing against precise multiplication.
+            if size <= 3 or dtype in [torch.cuda.IntTensor, torch.cuda.LongTensor]:
+                threshold = 0
+            elif size < 10:
+                threshold = 1e-4
+            elif size < 15:
+                threshold = 5e-4
+            else:
+                break
+
+            assert max_difference <= threshold, 'hvd.allreduce produces incorrect results'
+
+    def test_horovod_allreduce_error(self):
+        """Test that the allreduce raises an error if different ranks try to
+        send tensors of different rank or dimension."""
+        hvd.init()
+        rank = hvd.rank()
+        size = hvd.size()
+
+        # This test does not apply if there is only one worker.
+        if size == 1:
+            return
+
+        # Same rank, different dimension
         torch.manual_seed(1234)
-        tensor = torch.FloatTensor(*([17] * dim)).random_(-100, 100)
-        tensor = tensor.type(dtype)
-        summed = hvd.allreduce(tensor, average=False)
-        multiplied = tensor * size
-        max_difference = summed.sub(multiplied).max()
+        dims = [17 + rank] * 3
+        tensor = torch.FloatTensor(*dims).random_(-100, 100)
+        try:
+            hvd.allreduce(tensor)
+            assert False, 'hvd.allreduce did not throw error'
+        except torch.FatalError:
+            pass
 
-        # Threshold for floating point equality depends on number of
-        # ranks, since we're comparing against precise multiplication.
-        if size <= 3 or dtype in [torch.IntTensor, torch.LongTensor,
-                                  torch.cuda.IntTensor, torch.cuda.LongTensor]:
-            threshold = 0
-        elif size < 10:
-            threshold = 1e-4
-        elif size < 15:
-            threshold = 5e-4
-        else:
-            break
-
-        assert max_difference <= threshold, 'hvd.allreduce produces incorrect results'
-
-
-def test_horovod_allreduce_average():
-    """Test that the allreduce correctly sums 1D, 2D, 3D tensors."""
-    hvd.init()
-    size = hvd.size()
-    dtypes = [torch.IntTensor, torch.LongTensor,
-              torch.FloatTensor, torch.DoubleTensor]
-    if torch.cuda.is_available():
-        dtypes += [torch.cuda.IntTensor, torch.cuda.LongTensor,
-                   torch.cuda.FloatTensor, torch.cuda.DoubleTensor]
-    dims = [1, 2, 3]
-    for dtype, dim in itertools.product(dtypes, dims):
+        # Same number of elements, different rank
         torch.manual_seed(1234)
-        tensor = torch.FloatTensor(*([17] * dim)).random_(-100, 100)
-        tensor = tensor.type(dtype)
-        averaged = hvd.allreduce(tensor, average=True)
-        max_difference = averaged.sub(tensor).max()
-
-        # Threshold for floating point equality depends on number of
-        # ranks, since we're comparing against precise multiplication.
-        if size <= 3 or dtype in [torch.IntTensor, torch.LongTensor,
-                                  torch.cuda.IntTensor, torch.cuda.LongTensor]:
-            threshold = 0
-        elif size < 10:
-            threshold = 1e-4
-        elif size < 15:
-            threshold = 5e-4
+        if rank == 0:
+            dims = [17, 23 * 57]
         else:
-            break
+            dims = [17, 23, 57]
+        tensor = torch.FloatTensor(*dims).random_(-100, 100)
+        try:
+            hvd.allreduce(tensor)
+            assert False, 'hvd.allreduce did not throw error'
+        except torch.FatalError:
+            pass
 
-        assert max_difference <= threshold, 'hvd.allreduce produces incorrect results'
+    def test_horovod_allreduce_type_error(self):
+        """Test that the allreduce raises an error if different ranks try to
+        send tensors of different type."""
+        hvd.init()
+        rank = hvd.rank()
+        size = hvd.size()
 
+        # This test does not apply if there is only one worker.
+        if size == 1:
+            return
 
-def test_horovod_allreduce_inplace():
-    """Test that the allreduce correctly sums 1D, 2D, 3D tensors."""
-    hvd.init()
-    size = hvd.size()
-    dtypes = [torch.IntTensor, torch.LongTensor,
-              torch.FloatTensor, torch.DoubleTensor]
-    if torch.cuda.is_available():
-        dtypes += [torch.cuda.IntTensor, torch.cuda.LongTensor,
-                   torch.cuda.FloatTensor, torch.cuda.DoubleTensor]
-    dims = [1, 2, 3]
-    for dtype, dim in itertools.product(dtypes, dims):
-        torch.manual_seed(1234)
-        tensor = torch.FloatTensor(*([17] * dim)).random_(-100, 100)
-        tensor = tensor.type(dtype)
-        multiplied = tensor * size
-        hvd.allreduce_(tensor, average=False)
-        max_difference = tensor.sub(multiplied).max()
-
-        # Threshold for floating point equality depends on number of
-        # ranks, since we're comparing against precise multiplication.
-        if size <= 3 or dtype in [torch.IntTensor, torch.LongTensor,
-                                  torch.cuda.IntTensor, torch.cuda.LongTensor]:
-            threshold = 0
-        elif size < 10:
-            threshold = 1e-4
-        elif size < 15:
-            threshold = 5e-4
+        # Same rank, different dimension
+        dims = [17] * 3
+        if rank % 2 == 0:
+            tensor = torch.IntTensor(*dims)
         else:
-            break
+            tensor = torch.FloatTensor(*dims)
 
-        assert max_difference <= threshold, 'hvd.allreduce produces incorrect results'
+        try:
+            hvd.allreduce(tensor)
+            assert False, 'hvd.allreduce did not throw error'
+        except torch.FatalError:
+            pass
 
+    def test_horovod_allreduce_cpu_gpu_error(self):
+        """Test that the allreduce raises an error if different ranks try to
+        perform reduction on CPU and GPU."""
+        # Only do this test if there are GPUs available.
+        if not torch.cuda.is_available():
+            return
 
-def test_horovod_allreduce_async_fused():
-    """Test that the allreduce correctly sums 1D, 2D, 3D tensors
-    with Tensor Fusion."""
-    hvd.init()
-    size = hvd.size()
-    dtypes = [torch.IntTensor, torch.LongTensor,
-              torch.FloatTensor, torch.DoubleTensor]
-    if torch.cuda.is_available():
-        dtypes += [torch.cuda.IntTensor, torch.cuda.LongTensor,
-                   torch.cuda.FloatTensor, torch.cuda.DoubleTensor]
-    dims = [1, 2, 3]
-    tests = []
-    is_hvd_poll_false_once = False
-    for dtype, dim in itertools.product(dtypes, dims):
-        torch.manual_seed(1234)
-        tensor = torch.FloatTensor(*([17] * dim)).random_(-100, 100)
-        tensor = tensor.type(dtype)
-        handle = hvd.allreduce_async(tensor, average=False)
-        if not hvd.poll(handle):
-            is_hvd_poll_false_once = True
-        multiplied = tensor * size
-        tests.append((dtype, multiplied, handle))
+        hvd.init()
+        rank = hvd.rank()
+        size = hvd.size()
 
-    # Make sure it's an asynchronous operation.
-    assert is_hvd_poll_false_once, 'hvd.poll() always returns True, not an async op?'
+        # This test does not apply if there is only one worker.
+        if size == 1:
+            return
 
-    for dtype, multiplied, handle in tests:
-        summed = hvd.synchronize(handle)
-        max_difference = summed.sub(multiplied).max()
-
-        # Threshold for floating point equality depends on number of
-        # ranks, since we're comparing against precise multiplication.
-        if size <= 3 or dtype in [torch.IntTensor, torch.LongTensor,
-                                  torch.cuda.IntTensor, torch.cuda.LongTensor]:
-            threshold = 0
-        elif size < 10:
-            threshold = 1e-4
-        elif size < 15:
-            threshold = 5e-4
+        # Same rank, different dimension
+        dims = [17] * 3
+        if rank % 2 == 0:
+            tensor = torch.cuda.FloatTensor(*dims)
         else:
-            break
+            tensor = torch.FloatTensor(*dims)
 
-        assert max_difference <= threshold, 'hvd.allreduce produces incorrect results'
+        try:
+            hvd.allreduce(tensor)
+            assert False, 'hvd.allreduce did not throw error'
+        except torch.FatalError:
+            pass
 
+    def test_horovod_allreduce_grad(self):
+        """Test the correctness of the allreduce gradient."""
+        hvd.init()
+        size = hvd.size()
+        dtypes = [torch.IntTensor, torch.LongTensor,
+                  torch.FloatTensor, torch.DoubleTensor]
+        if torch.cuda.is_available():
+            dtypes += [torch.cuda.IntTensor, torch.cuda.LongTensor,
+                       torch.cuda.FloatTensor, torch.cuda.DoubleTensor]
+        dims = [1, 2, 3]
+        for dtype, dim in itertools.product(dtypes, dims):
+            torch.manual_seed(1234)
+            tensor = torch.FloatTensor(*([17] * dim)).random_(-100, 100)
+            tensor = tensor.type(dtype)
+            tensor.requires_grad_()
+            summed = hvd.allreduce(tensor, average=False)
 
-def test_horovod_allreduce_multi_gpu():
-    """Test that the allreduce works on multiple GPUs."""
-    # Only do this test if there are GPUs available.
-    if not torch.cuda.is_available():
-        return
+            summed.backward(torch.ones([17] * dim))
+            grad_out = tensor.grad.numpy()
 
-    hvd.init()
-    local_rank = hvd.local_rank()
-    size = hvd.size()
+            expected = np.ones([17] * dim) * size
+            err = np.linalg.norm(expected - grad_out)
+            self.assertLess(err, 0.00000001,
+                            "gradient %s differs from expected %s, "
+                            "error: %s" % (grad_out, expected, str(err)))
 
-    iter = 0
-    dtypes = [torch.cuda.IntTensor, torch.cuda.LongTensor,
-              torch.cuda.FloatTensor, torch.cuda.DoubleTensor]
-    dims = [1, 2, 3]
-    for dtype, dim in itertools.product(dtypes, dims):
-        iter += 1
-        torch.manual_seed(1234)
-        tensor = torch.FloatTensor(*([17] * dim)).random_(-100, 100)
-        device = local_rank * 2 + (iter + local_rank) % 2
-        tensor = tensor.cuda(device).type(dtype)
-        multiplied = tensor * size
-        hvd.allreduce_(tensor, average=False)
-        max_difference = tensor.sub(multiplied).max()
+    def test_horovod_allreduce_grad_average(self):
+        """Test the correctness of the allreduce averaged gradient."""
+        hvd.init()
+        dtypes = [torch.IntTensor, torch.LongTensor,
+                  torch.FloatTensor, torch.DoubleTensor]
+        if torch.cuda.is_available():
+            dtypes += [torch.cuda.IntTensor, torch.cuda.LongTensor,
+                       torch.cuda.FloatTensor, torch.cuda.DoubleTensor]
+        dims = [1, 2, 3]
+        for dtype, dim in itertools.product(dtypes, dims):
+            torch.manual_seed(1234)
+            tensor = torch.FloatTensor(*([17] * dim)).random_(-100, 100)
+            tensor = tensor.type(dtype)
+            tensor.requires_grad_()
+            summed = hvd.allreduce(tensor, average=True)
 
-        # Threshold for floating point equality depends on number of
-        # ranks, since we're comparing against precise multiplication.
-        if size <= 3 or dtype in [torch.cuda.IntTensor, torch.cuda.LongTensor]:
-            threshold = 0
-        elif size < 10:
-            threshold = 1e-4
-        elif size < 15:
-            threshold = 5e-4
+            summed.backward(torch.ones([17] * dim))
+            grad_out = tensor.grad.numpy()
+
+            expected = np.ones([17] * dim)
+            err = np.linalg.norm(expected - grad_out)
+            self.assertLess(err, 0.00000001,
+                            "gradient %s differs from expected %s, "
+                            "error: %s" % (grad_out, expected, str(err)))
+
+    def test_horovod_allgather(self):
+        """Test that the allgather correctly gathers 1D, 2D, 3D tensors."""
+        hvd.init()
+        rank = hvd.rank()
+        size = hvd.size()
+
+        dtypes = [torch.ByteTensor, torch.CharTensor, torch.ShortTensor,
+                  torch.IntTensor, torch.LongTensor, torch.FloatTensor, torch.DoubleTensor]
+        if torch.cuda.is_available():
+            dtypes += [torch.cuda.ByteTensor, torch.cuda.CharTensor, torch.cuda.ShortTensor,
+                       torch.cuda.IntTensor, torch.cuda.LongTensor, torch.cuda.FloatTensor,
+                       torch.cuda.DoubleTensor]
+        dims = [1, 2, 3]
+        for dtype, dim in itertools.product(dtypes, dims):
+            tensor = torch.FloatTensor(*([17] * dim)).fill_(1).mul_(rank)
+            tensor = tensor.type(dtype)
+            gathered = hvd.allgather(tensor)
+
+            assert list(gathered.shape) == [17 * size] + [17] * (dim - 1)
+
+            for i in range(size):
+                rank_tensor = gathered[i * 17:(i + 1) * 17]
+                assert list(rank_tensor.shape) == [17] * dim, \
+                    'hvd.allgather produces incorrect gathered shape'
+                assert rank_tensor.min() == i, 'hvd.allgather produces incorrect gathered tensor'
+                assert rank_tensor.max() == i, 'hvd.allgather produces incorrect gathered tensor'
+
+    def test_horovod_allgather_variable_size(self):
+        """Test that the allgather correctly gathers 1D, 2D, 3D tensors,
+        even if those tensors have different sizes along the first dim."""
+        hvd.init()
+        rank = hvd.rank()
+        size = hvd.size()
+
+        dtypes = [torch.ByteTensor, torch.CharTensor, torch.ShortTensor,
+                  torch.IntTensor, torch.LongTensor, torch.FloatTensor, torch.DoubleTensor]
+        if torch.cuda.is_available():
+            dtypes += [torch.cuda.ByteTensor, torch.cuda.CharTensor, torch.cuda.ShortTensor,
+                       torch.cuda.IntTensor, torch.cuda.LongTensor, torch.cuda.FloatTensor,
+                       torch.cuda.DoubleTensor]
+        dims = [1, 2, 3]
+        for dtype, dim in itertools.product(dtypes, dims):
+            # Support tests up to MPI Size of 35
+            if size > 35:
+                break
+
+            tensor_sizes = [17, 32, 81, 12, 15, 23, 22] * 5
+            tensor_sizes = tensor_sizes[:size]
+
+            tensor = torch.FloatTensor(
+                *([tensor_sizes[rank]] + [17] * (dim - 1))).fill_(1).mul_(rank)
+            tensor = tensor.type(dtype)
+            gathered = hvd.allgather(tensor)
+
+            expected_size = sum(tensor_sizes)
+            assert list(gathered.shape) == [expected_size] + [17] * (dim - 1)
+
+            for i in range(size):
+                rank_size = [tensor_sizes[i]] + [17] * (dim - 1)
+                rank_tensor = gathered[sum(
+                    tensor_sizes[:i]):sum(tensor_sizes[:i + 1])]
+                assert list(rank_tensor.shape) == rank_size
+                assert rank_tensor.min() == i
+                assert rank_tensor.max() == i
+
+    def test_horovod_allgather_error(self):
+        """Test that the allgather returns an error if any dimension besides
+        the first is different among the tensors being gathered."""
+        hvd.init()
+        rank = hvd.rank()
+        size = hvd.size()
+
+        # This test does not apply if there is only one worker.
+        if size == 1:
+            return
+
+        tensor_size = [17] * 3
+        tensor_size[1] = 10 * (rank + 1)
+        tensor = torch.FloatTensor(*tensor_size).fill_(1).mul_(rank)
+
+        try:
+            hvd.allgather(tensor)
+            assert False, 'hvd.allgather did not throw error'
+        except torch.FatalError:
+            pass
+
+    def test_horovod_allgather_type_error(self):
+        """Test that the allgather returns an error if the types being gathered
+        differ among the processes"""
+        hvd.init()
+        rank = hvd.rank()
+        size = hvd.size()
+
+        # This test does not apply if there is only one worker.
+        if size == 1:
+            return
+
+        tensor_size = [17] * 3
+        if rank % 2 == 0:
+            tensor = torch.IntTensor(*tensor_size)
         else:
-            break
+            tensor = torch.FloatTensor(*tensor_size)
 
-        assert max_difference <= threshold, 'hvd.allreduce produces incorrect results'
+        try:
+            hvd.allgather(tensor)
+            assert False, 'hvd.allgather did not throw error'
+        except torch.FatalError:
+            pass
 
+    def test_horovod_allgather_grad(self):
+        """Test the correctness of the allgather gradient."""
+        hvd.init()
+        rank = hvd.rank()
+        size = hvd.size()
 
-def test_horovod_allreduce_error():
-    """Test that the allreduce raises an error if different ranks try to
-    send tensors of different rank or dimension."""
-    hvd.init()
-    rank = hvd.rank()
-    size = hvd.size()
+        dtypes = [torch.ByteTensor, torch.CharTensor, torch.ShortTensor,
+                  torch.IntTensor, torch.LongTensor, torch.FloatTensor, torch.DoubleTensor]
+        if torch.cuda.is_available():
+            dtypes += [torch.cuda.ByteTensor, torch.cuda.CharTensor, torch.cuda.ShortTensor,
+                       torch.cuda.IntTensor, torch.cuda.LongTensor, torch.cuda.FloatTensor,
+                       torch.cuda.DoubleTensor]
+        dims = [1, 2, 3]
+        for dtype, dim in itertools.product(dtypes, dims):
+            # Support tests up to MPI Size of 35
+            if size > 35:
+                break
 
-    # This test does not apply if there is only one worker.
-    if size == 1:
-        return
+            tensor_sizes = [3, 2, 7, 4, 6, 8, 10] * 5
+            tensor_sizes = tensor_sizes[:size]
 
-    # Same rank, different dimension
-    torch.manual_seed(1234)
-    dims = [17 + rank] * 3
-    tensor = torch.FloatTensor(*dims).random_(-100, 100)
-    try:
-        hvd.allreduce(tensor)
-        assert False, 'hvd.allreduce did not throw error'
-    except torch.FatalError:
-        pass
+            tensor = torch.FloatTensor(
+                *([tensor_sizes[rank]] + [17] * (dim - 1))).fill_(1).mul_(rank)
+            tensor = tensor.type(dtype)
+            tensor.requires_grad_()
 
-    # Same number of elements, different rank
-    torch.manual_seed(1234)
-    if rank == 0:
-        dims = [17, 23 * 57]
-    else:
-        dims = [17, 23, 57]
-    tensor = torch.FloatTensor(*dims).random_(-100, 100)
-    try:
-        hvd.allreduce(tensor)
-        assert False, 'hvd.allreduce did not throw error'
-    except torch.FatalError:
-        pass
+            grad_list = []
+            for r, size in enumerate(tensor_sizes):
+                grad_list.append(torch.ones([size] + [17] * (dim - 1)) * r)
+            grad_ys = torch.cat(grad_list, dim=0)
 
+            gathered = hvd.allgather(tensor)
+            gathered.backward(grad_ys)
+            grad_out = tensor.grad.numpy()
 
-def test_horovod_allreduce_type_error():
-    """Test that the allreduce raises an error if different ranks try to
-    send tensors of different type."""
-    hvd.init()
-    rank = hvd.rank()
-    size = hvd.size()
+            expected = np.ones(
+                [tensor_sizes[rank]] + [17] * (dim - 1)
+            ) * rank * size
+            err = np.linalg.norm(expected - grad_out)
+            self.assertLess(err, 0.00000001,
+                            "gradient %s differs from expected %s, "
+                            "error: %s" % (grad_out, expected, str(err)))
 
-    # This test does not apply if there is only one worker.
-    if size == 1:
-        return
+    def test_horovod_broadcast(self):
+        """Test that the broadcast correctly broadcasts 1D, 2D, 3D tensors."""
+        hvd.init()
+        rank = hvd.rank()
+        size = hvd.size()
 
-    # Same rank, different dimension
-    dims = [17] * 3
-    if rank % 2 == 0:
-        tensor = torch.IntTensor(*dims)
-    else:
-        tensor = torch.FloatTensor(*dims)
+        # This test does not apply if there is only one worker.
+        if size == 1:
+            return
 
-    try:
-        hvd.allreduce(tensor)
-        assert False, 'hvd.allreduce did not throw error'
-    except torch.FatalError:
-        pass
+        dtypes = [torch.ByteTensor, torch.CharTensor, torch.ShortTensor,
+                  torch.IntTensor, torch.LongTensor, torch.FloatTensor, torch.DoubleTensor]
+        if torch.cuda.is_available():
+            dtypes += [torch.cuda.ByteTensor, torch.cuda.CharTensor, torch.cuda.ShortTensor,
+                       torch.cuda.IntTensor, torch.cuda.LongTensor, torch.cuda.FloatTensor,
+                       torch.cuda.DoubleTensor]
+        dims = [1, 2, 3]
+        root_ranks = list(range(size))
+        for dtype, dim, root_rank in itertools.product(dtypes, dims, root_ranks):
+            tensor = torch.FloatTensor(*([17] * dim)).fill_(1).mul_(rank)
+            root_tensor = torch.FloatTensor(*([17] * dim)).fill_(1).mul_(root_rank)
+            tensor = tensor.type(dtype)
+            root_tensor = root_tensor.type(dtype)
+            broadcasted_tensor = hvd.broadcast(tensor, root_rank)
+            if rank != root_rank:
+                assert (tensor == root_tensor).max() == 0, \
+                    'hvd.broadcast modifies source tensor'
+            assert (broadcasted_tensor == root_tensor).min() == 1, \
+                'hvd.broadcast produces incorrect broadcasted tensor'
 
+    def test_horovod_broadcast_inplace(self):
+        """Test that the broadcast correctly broadcasts 1D, 2D, 3D tensors."""
+        hvd.init()
+        rank = hvd.rank()
+        size = hvd.size()
 
-def test_horovod_allreduce_cpu_gpu_error():
-    """Test that the allreduce raises an error if different ranks try to
-    perform reduction on CPU and GPU."""
-    # Only do this test if there are GPUs available.
-    if not torch.cuda.is_available():
-        return
+        # This test does not apply if there is only one worker.
+        if size == 1:
+            return
 
-    hvd.init()
-    rank = hvd.rank()
-    size = hvd.size()
+        dtypes = [torch.ByteTensor, torch.CharTensor, torch.ShortTensor,
+                  torch.IntTensor, torch.LongTensor, torch.FloatTensor, torch.DoubleTensor]
+        if torch.cuda.is_available():
+            dtypes += [torch.cuda.ByteTensor, torch.cuda.CharTensor, torch.cuda.ShortTensor,
+                       torch.cuda.IntTensor, torch.cuda.LongTensor, torch.cuda.FloatTensor,
+                       torch.cuda.DoubleTensor]
+        dims = [1, 2, 3]
+        root_ranks = list(range(size))
+        for dtype, dim, root_rank in itertools.product(dtypes, dims, root_ranks):
+            tensor = torch.FloatTensor(*([17] * dim)).fill_(1).mul_(rank)
+            root_tensor = torch.FloatTensor(*([17] * dim)).fill_(1).mul_(root_rank)
+            tensor = tensor.type(dtype)
+            root_tensor = root_tensor.type(dtype)
+            broadcasted_tensor = hvd.broadcast_(tensor, root_rank)
+            assert (tensor == broadcasted_tensor).min() == 1, \
+                'hvd.broadcast does not modify source tensor'
+            assert (broadcasted_tensor == root_tensor).min() == 1, \
+                'hvd.broadcast produces incorrect broadcasted tensor'
 
-    # This test does not apply if there is only one worker.
-    if size == 1:
-        return
+    def test_horovod_broadcast_error(self):
+        """Test that the broadcast returns an error if any dimension besides
+        the first is different among the tensors being broadcasted."""
+        hvd.init()
+        rank = hvd.rank()
+        size = hvd.size()
 
-    # Same rank, different dimension
-    dims = [17] * 3
-    if rank % 2 == 0:
-        tensor = torch.cuda.FloatTensor(*dims)
-    else:
-        tensor = torch.FloatTensor(*dims)
+        # This test does not apply if there is only one worker.
+        if size == 1:
+            return
 
-    try:
-        hvd.allreduce(tensor)
-        assert False, 'hvd.allreduce did not throw error'
-    except torch.FatalError:
-        pass
+        tensor_size = [17] * 3
+        tensor_size[1] = 10 * (rank + 1)
+        tensor = torch.FloatTensor(*tensor_size).fill_(1).mul_(rank)
 
+        try:
+            hvd.broadcast(tensor, 0)
+            assert False, 'hvd.broadcast did not throw error'
+        except torch.FatalError:
+            pass
 
-def test_horovod_allgather():
-    """Test that the allgather correctly gathers 1D, 2D, 3D tensors."""
-    hvd.init()
-    rank = hvd.rank()
-    size = hvd.size()
+    def test_horovod_broadcast_type_error(self):
+        """Test that the broadcast returns an error if the types being broadcasted
+        differ among the processes"""
+        hvd.init()
+        rank = hvd.rank()
+        size = hvd.size()
 
-    dtypes = [torch.ByteTensor, torch.CharTensor, torch.ShortTensor,
-              torch.IntTensor, torch.LongTensor, torch.FloatTensor, torch.DoubleTensor]
-    if torch.cuda.is_available():
-        dtypes += [torch.cuda.ByteTensor, torch.cuda.CharTensor, torch.cuda.ShortTensor,
-                   torch.cuda.IntTensor, torch.cuda.LongTensor, torch.cuda.FloatTensor,
-                   torch.cuda.DoubleTensor]
-    dims = [1, 2, 3]
-    for dtype, dim in itertools.product(dtypes, dims):
-        tensor = torch.FloatTensor(*([17] * dim)).fill_(1).mul_(rank)
-        tensor = tensor.type(dtype)
-        gathered = hvd.allgather(tensor)
+        # This test does not apply if there is only one worker.
+        if size == 1:
+            return
 
-        assert list(gathered.shape) == [17 * size] + [17] * (dim - 1)
+        tensor_size = [17] * 3
+        if rank % 2 == 0:
+            tensor = torch.IntTensor(*tensor_size)
+        else:
+            tensor = torch.FloatTensor(*tensor_size)
 
-        for i in range(size):
-            rank_tensor = gathered[i * 17:(i + 1) * 17]
-            assert list(rank_tensor.shape) == [17] * dim, \
-                'hvd.allgather produces incorrect gathered shape'
-            assert rank_tensor.min() == i, 'hvd.allgather produces incorrect gathered tensor'
-            assert rank_tensor.max() == i, 'hvd.allgather produces incorrect gathered tensor'
+        try:
+            hvd.broadcast(tensor, 0)
+            assert False, 'hvd.broadcast did not throw error'
+        except torch.FatalError:
+            pass
 
+    def test_horovod_broadcast_rank_error(self):
+        """Test that the broadcast returns an error if different ranks
+        specify different root rank."""
+        hvd.init()
+        rank = hvd.rank()
+        size = hvd.size()
 
-def test_horovod_allgather_variable_size():
-    """Test that the allgather correctly gathers 1D, 2D, 3D tensors,
-    even if those tensors have different sizes along the first dim."""
-    hvd.init()
-    rank = hvd.rank()
-    size = hvd.size()
+        # This test does not apply if there is only one worker.
+        if size == 1:
+            return
 
-    dtypes = [torch.ByteTensor, torch.CharTensor, torch.ShortTensor,
-              torch.IntTensor, torch.LongTensor, torch.FloatTensor, torch.DoubleTensor]
-    if torch.cuda.is_available():
-        dtypes += [torch.cuda.ByteTensor, torch.cuda.CharTensor, torch.cuda.ShortTensor,
-                   torch.cuda.IntTensor, torch.cuda.LongTensor, torch.cuda.FloatTensor,
-                   torch.cuda.DoubleTensor]
-    dims = [1, 2, 3]
-    for dtype, dim in itertools.product(dtypes, dims):
-        # Support tests up to MPI Size of 35
-        if size > 35:
-            break
+        tensor = torch.FloatTensor(*([17] * 3)).fill_(1)
 
-        tensor_sizes = [17, 32, 81, 12, 15, 23, 22] * 5
-        tensor_sizes = tensor_sizes[:size]
+        try:
+            hvd.broadcast(tensor, rank)
+            assert False, 'hvd.broadcast did not throw error'
+        except torch.FatalError:
+            pass
 
-        tensor = torch.FloatTensor(
-            *([tensor_sizes[rank]] + [17] * (dim - 1))).fill_(1).mul_(rank)
-        tensor = tensor.type(dtype)
-        gathered = hvd.allgather(tensor)
+    def test_horovod_broadcast_grad(self):
+        """Test the correctness of the broadcast gradient."""
+        hvd.init()
+        rank = hvd.rank()
+        size = hvd.size()
 
-        expected_size = sum(tensor_sizes)
-        assert list(gathered.shape) == [expected_size] + [17] * (dim - 1)
+        # This test does not apply if there is only one worker.
+        if size == 1:
+            return
 
-        for i in range(size):
-            rank_size = [tensor_sizes[i]] + [17] * (dim - 1)
-            rank_tensor = gathered[sum(
-                tensor_sizes[:i]):sum(tensor_sizes[:i + 1])]
-            assert list(rank_tensor.shape) == rank_size
-            assert rank_tensor.min() == i
-            assert rank_tensor.max() == i
+        dtypes = [torch.ByteTensor, torch.CharTensor, torch.ShortTensor,
+                  torch.IntTensor, torch.LongTensor, torch.FloatTensor, torch.DoubleTensor]
+        if torch.cuda.is_available():
+            dtypes += [torch.cuda.ByteTensor, torch.cuda.CharTensor, torch.cuda.ShortTensor,
+                       torch.cuda.IntTensor, torch.cuda.LongTensor, torch.cuda.FloatTensor,
+                       torch.cuda.DoubleTensor]
+        dims = [1, 2, 3]
+        root_ranks = list(range(size))
+        for dtype, dim, root_rank in itertools.product(dtypes, dims, root_ranks):
+            tensor = torch.FloatTensor(*([17] * dim)).fill_(1).mul_(rank)
+            tensor = tensor.type(dtype)
+            tensor.requires_grad_()
 
+            broadcasted_tensor = hvd.broadcast(tensor, root_rank)
+            broadcasted_tensor.backward(torch.ones([17] * dim))
+            grad_out = tensor.grad.numpy()
 
-def test_horovod_allgather_error():
-    """Test that the allgather returns an error if any dimension besides
-    the first is different among the tensors being gathered."""
-    hvd.init()
-    rank = hvd.rank()
-    size = hvd.size()
-
-    # This test does not apply if there is only one worker.
-    if size == 1:
-        return
-
-    tensor_size = [17] * 3
-    tensor_size[1] = 10 * (rank + 1)
-    tensor = torch.FloatTensor(*tensor_size).fill_(1).mul_(rank)
-
-    try:
-        hvd.allgather(tensor)
-        assert False, 'hvd.allgather did not throw error'
-    except torch.FatalError:
-        pass
-
-
-def test_horovod_allgather_type_error():
-    """Test that the allgather returns an error if the types being gathered
-    differ among the processes"""
-    hvd.init()
-    rank = hvd.rank()
-    size = hvd.size()
-
-    # This test does not apply if there is only one worker.
-    if size == 1:
-        return
-
-    tensor_size = [17] * 3
-    if rank % 2 == 0:
-        tensor = torch.IntTensor(*tensor_size)
-    else:
-        tensor = torch.FloatTensor(*tensor_size)
-
-    try:
-        hvd.allgather(tensor)
-        assert False, 'hvd.allgather did not throw error'
-    except torch.FatalError:
-        pass
-
-
-def test_horovod_broadcast():
-    """Test that the broadcast correctly broadcasts 1D, 2D, 3D tensors."""
-    hvd.init()
-    rank = hvd.rank()
-    size = hvd.size()
-
-    # This test does not apply if there is only one worker.
-    if size == 1:
-        return
-
-    dtypes = [torch.ByteTensor, torch.CharTensor, torch.ShortTensor,
-              torch.IntTensor, torch.LongTensor, torch.FloatTensor, torch.DoubleTensor]
-    if torch.cuda.is_available():
-        dtypes += [torch.cuda.ByteTensor, torch.cuda.CharTensor, torch.cuda.ShortTensor,
-                   torch.cuda.IntTensor, torch.cuda.LongTensor, torch.cuda.FloatTensor,
-                   torch.cuda.DoubleTensor]
-    dims = [1, 2, 3]
-    root_ranks = list(range(size))
-    for dtype, dim, root_rank in itertools.product(dtypes, dims, root_ranks):
-        tensor = torch.FloatTensor(*([17] * dim)).fill_(1).mul_(rank)
-        root_tensor = torch.FloatTensor(*([17] * dim)).fill_(1).mul_(root_rank)
-        tensor = tensor.type(dtype)
-        root_tensor = root_tensor.type(dtype)
-        broadcasted_tensor = hvd.broadcast(tensor, root_rank)
-        if rank != root_rank:
-            assert (tensor == root_tensor).max() == 0, \
-                'hvd.broadcast modifies source tensor'
-        assert (broadcasted_tensor == root_tensor).min() == 1, \
-            'hvd.broadcast produces incorrect broadcasted tensor'
-
-
-def test_horovod_broadcast_inplace():
-    """Test that the broadcast correctly broadcasts 1D, 2D, 3D tensors."""
-    hvd.init()
-    rank = hvd.rank()
-    size = hvd.size()
-
-    # This test does not apply if there is only one worker.
-    if size == 1:
-        return
-
-    dtypes = [torch.ByteTensor, torch.CharTensor, torch.ShortTensor,
-              torch.IntTensor, torch.LongTensor, torch.FloatTensor, torch.DoubleTensor]
-    if torch.cuda.is_available():
-        dtypes += [torch.cuda.ByteTensor, torch.cuda.CharTensor, torch.cuda.ShortTensor,
-                   torch.cuda.IntTensor, torch.cuda.LongTensor, torch.cuda.FloatTensor,
-                   torch.cuda.DoubleTensor]
-    dims = [1, 2, 3]
-    root_ranks = list(range(size))
-    for dtype, dim, root_rank in itertools.product(dtypes, dims, root_ranks):
-        tensor = torch.FloatTensor(*([17] * dim)).fill_(1).mul_(rank)
-        root_tensor = torch.FloatTensor(*([17] * dim)).fill_(1).mul_(root_rank)
-        tensor = tensor.type(dtype)
-        root_tensor = root_tensor.type(dtype)
-        broadcasted_tensor = hvd.broadcast_(tensor, root_rank)
-        assert (tensor == broadcasted_tensor).min() == 1, \
-            'hvd.broadcast does not modify source tensor'
-        assert (broadcasted_tensor == root_tensor).min() == 1, \
-            'hvd.broadcast produces incorrect broadcasted tensor'
-
-
-def test_horovod_broadcast_error():
-    """Test that the broadcast returns an error if any dimension besides
-    the first is different among the tensors being broadcasted."""
-    hvd.init()
-    rank = hvd.rank()
-    size = hvd.size()
-
-    # This test does not apply if there is only one worker.
-    if size == 1:
-        return
-
-    tensor_size = [17] * 3
-    tensor_size[1] = 10 * (rank + 1)
-    tensor = torch.FloatTensor(*tensor_size).fill_(1).mul_(rank)
-
-    try:
-        hvd.broadcast(tensor, 0)
-        assert False, 'hvd.broadcast did not throw error'
-    except torch.FatalError:
-        pass
-
-
-def test_horovod_broadcast_type_error():
-    """Test that the broadcast returns an error if the types being broadcasted
-    differ among the processes"""
-    hvd.init()
-    rank = hvd.rank()
-    size = hvd.size()
-
-    # This test does not apply if there is only one worker.
-    if size == 1:
-        return
-
-    tensor_size = [17] * 3
-    if rank % 2 == 0:
-        tensor = torch.IntTensor(*tensor_size)
-    else:
-        tensor = torch.FloatTensor(*tensor_size)
-
-    try:
-        hvd.broadcast(tensor, 0)
-        assert False, 'hvd.broadcast did not throw error'
-    except torch.FatalError:
-        pass
-
-
-def test_horovod_broadcast_rank_error():
-    """Test that the broadcast returns an error if different ranks
-    specify different root rank."""
-    hvd.init()
-    rank = hvd.rank()
-    size = hvd.size()
-
-    # This test does not apply if there is only one worker.
-    if size == 1:
-        return
-
-    tensor = torch.FloatTensor(*([17] * 3)).fill_(1)
-
-    try:
-        hvd.broadcast(tensor, rank)
-        assert False, 'hvd.broadcast did not throw error'
-    except torch.FatalError:
-        pass
+            c = size if rank == root_rank else 0
+            expected = np.ones([17] * dim) * c
+            err = np.linalg.norm(expected - grad_out)
+            self.assertLess(err, 0.00000001,
+                            "gradient %s differs from expected %s, "
+                            "error: %s" % (grad_out, expected, str(err)))


### PR DESCRIPTION
Note: only made the synchronous functions that do not modify tensors in place differentiable.  The reasoning here is that modifying tensors in place and performing async ops doesn't lend itself conceptually well to the concept of a graph, but open to adding additional support.

Because the input tensor needs to have the property requires_grad for this to do anything, there should not be any additional memory or compute cost from this implementation.