### PR TITLE
C++11 syntax enhancement

### DIFF
--- a/horovod/common/common.cc
+++ b/horovod/common/common.cc
@@ -14,15 +14,14 @@
 // =============================================================================
 
 #include <sstream>
-#include <assert.h>
+#include <cassert>
 
 #include "common.h"
 
 namespace horovod {
 namespace common {
 
-Status::Status() {
-}
+Status::Status() = default;
 
 Status::Status(StatusType type, std::string reason) {
   type_ = type;

--- a/horovod/common/common.h
+++ b/horovod/common/common.h
@@ -74,7 +74,7 @@ private:
 class ReadyEvent {
 public:
   virtual bool Ready() const = 0;
-  virtual ~ReadyEvent(){};
+  virtual ~ReadyEvent() = default;
 };
 
 class OpContext;
@@ -82,7 +82,7 @@ class OpContext;
 class PersistentBuffer {
 public:
   virtual const void* AccessData(std::shared_ptr<OpContext> context) const = 0;
-  virtual ~PersistentBuffer(){};
+  virtual ~PersistentBuffer() = default;
 };
 
 class Tensor {
@@ -91,7 +91,7 @@ public:
   virtual const TensorShape shape() const = 0;
   virtual const void* data() const = 0;
   virtual int64_t size() const = 0;
-  virtual ~Tensor(){};
+  virtual ~Tensor() = default;
 };
 
 class OpContext {
@@ -103,7 +103,7 @@ public:
   virtual Status AllocateOutput(TensorShape shape,
                                 std::shared_ptr<Tensor>* tensor) = 0;
   virtual Framework framework() const = 0;
-  virtual ~OpContext(){};
+  virtual ~OpContext() = default;
 };
 
 } // namespace common

--- a/horovod/common/hashes.h
+++ b/horovod/common/hashes.h
@@ -36,8 +36,8 @@ inline std::size_t hash_one(const T& element, std::size_t seed) {
 } // namespace
 
 template <typename T> struct hash<std::vector<T>> {
-  typedef std::vector<T> argument_type;
-  typedef std::size_t result_type;
+  using argument_type = std::vector<T>;
+  using result_type = std::size_t;
 
   result_type operator()(argument_type const& in) const {
     size_t size = in.size();
@@ -49,8 +49,8 @@ template <typename T> struct hash<std::vector<T>> {
 };
 
 template <typename U, typename V> struct hash<std::tuple<U, V>> {
-  typedef std::tuple<U, V> argument_type;
-  typedef std::size_t result_type;
+  using argument_type = std::tuple<U, V>;
+  using result_type = std::size_t;
 
   result_type operator()(argument_type const& in) const {
     result_type seed = 0;

--- a/horovod/common/operations.cc
+++ b/horovod/common/operations.cc
@@ -98,10 +98,9 @@ using TensorTable = std::unordered_map<std::string, TensorTableEntry>;
 // Table for storing Tensor metadata on rank zero. This is used for error
 // checking, stall checking and size calculations, as well as determining
 // when a reduction is ready to be done (when all nodes are ready to do it).
-typedef std::unordered_map<
+using MessageTable = std::unordered_map<
     std::string,
-    std::tuple<std::vector<MPIRequest>, std::chrono::steady_clock::time_point>>
-    MessageTable;
+    std::tuple<std::vector<MPIRequest>, std::chrono::steady_clock::time_point>>;
 
 // The global state required for the MPI ops.
 //

--- a/horovod/common/operations.cc
+++ b/horovod/common/operations.cc
@@ -75,7 +75,7 @@ namespace {
 
 // Table storing Tensors to be reduced, keyed by unique name.
 // This table contains everything necessary to do the reduction.
-typedef struct {
+struct TensorTableEntry {
   // Name of the tensor.
   std::string tensor_name;
   // Operation context.
@@ -92,8 +92,8 @@ typedef struct {
   int device;
   // A callback to call with the status.
   StatusCallback callback;
-} TensorTableEntry;
-typedef std::unordered_map<std::string, TensorTableEntry> TensorTable;
+};
+using TensorTable = std::unordered_map<std::string, TensorTableEntry>;
 
 // Table for storing Tensor metadata on rank zero. This is used for error
 // checking, stall checking and size calculations, as well as determining

--- a/horovod/common/operations.h
+++ b/horovod/common/operations.h
@@ -44,7 +44,7 @@ namespace common {
 // A callback to call after the MPI communication completes. Since the
 // allreduce and allgather ops are asynchronous, this callback is what resumes
 // computation after the reduction is completed.
-typedef std::function<void(const Status&)> StatusCallback;
+using StatusCallback = std::function<void(const Status&)>;
 
 // Check that Horovod is initialized.
 Status CheckInitialized();

--- a/horovod/common/timeline.cc
+++ b/horovod/common/timeline.cc
@@ -14,7 +14,7 @@
 // =============================================================================
 
 #include <sstream>
-#include <assert.h>
+#include <cassert>
 
 #include "timeline.h"
 


### PR DESCRIPTION
- another recommendation

in `horovod/common/timeline.cc`:
those escaped `"` can be rewritten as raw string literal