### PR TITLE
Initialize Horovod with the provided MPI ranks or MPI communicator

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,8 +254,6 @@ provided that the MPI was built with multi-threading support.
 
 You can check for MPI multi-threading support by querying the `hvd.mpi_threads_supported()` function.
 
-**Note**: Make sure that MPI library will **NOT** re-initialize MPI.  For example:
-
 ```python
 import horovod.tensorflow as hvd
 
@@ -264,10 +262,6 @@ hvd.init()
 
 # Verify that MPI multi-threading is supported.
 assert hvd.mpi_threads_supported()
-
-# Make sure MPI is not re-initialized.
-import mpi4py.rc
-mpi4py.rc.initialize = False
 
 from mpi4py import MPI
 assert hvd.size() == MPI.COMM_WORLD.Get_size()

--- a/horovod/common/__init__.py
+++ b/horovod/common/__init__.py
@@ -60,7 +60,7 @@ def init(comm=None):
     if comm is None:
         comm = []
 
-    atexit.register(shutdown, finalize=True)
+    atexit.register(shutdown)
 
     if not isinstance(comm, list):
         from mpi4py import MPI
@@ -78,8 +78,8 @@ def init(comm=None):
             (ctypes.c_int * comm_size)(*comm), ctypes.c_int(comm_size))
 
 
-def shutdown(finalize=False):
-    return MPI_COMMON_LIB_CTYPES.horovod_shutdown(ctypes.c_bool(finalize))
+def shutdown():
+    return MPI_COMMON_LIB_CTYPES.horovod_shutdown()
 
 
 def size():

--- a/horovod/common/__init__.py
+++ b/horovod/common/__init__.py
@@ -47,6 +47,7 @@ MPI_COMMON_LIB_CTYPES = \
     ctypes.CDLL(os.path.join(os.path.dirname(__file__),
                              'mpi_lib' + get_ext_suffix()), mode=ctypes.RTLD_GLOBAL)
 
+
 def init(comm=None):
     """A function that initializes Horovod.
 
@@ -57,9 +58,9 @@ def init(comm=None):
 
     """
     if comm is None:
-        comm=[]
+        comm = []
 
-    atexit.register(terminate, finalize=True)
+    atexit.register(shutdown, finalize=True)
 
     if not isinstance(comm, list):
         from mpi4py import MPI
@@ -73,10 +74,13 @@ def init(comm=None):
         return MPI_COMMON_LIB_CTYPES.horovod_init_comm(comm_obj)
     else:
         comm_size = len(comm)
-        return MPI_COMMON_LIB_CTYPES.horovod_init((ctypes.c_int * comm_size)(*comm), ctypes.c_int(comm_size))
+        return MPI_COMMON_LIB_CTYPES.horovod_init(
+            (ctypes.c_int * comm_size)(*comm), ctypes.c_int(comm_size))
 
-def terminate(finalize=False):
-    return MPI_COMMON_LIB_CTYPES.horovod_terminate(ctypes.c_bool(finalize))
+
+def shutdown(finalize=False):
+    return MPI_COMMON_LIB_CTYPES.horovod_shutdown(ctypes.c_bool(finalize))
+
 
 def size():
     """A function that returns the number of Horovod processes.

--- a/horovod/common/__init__.py
+++ b/horovod/common/__init__.py
@@ -51,13 +51,15 @@ def init(comm=None):
     """A function that initializes Horovod.
 
     Args:
-      comm: List specifying ranks for the communicator, relative to the WORLD communicator OR
-        the MPI communicator to use.
-        If None, horovod will use WORLD Communicator.
+      comm: List specifying ranks for the communicator, relative to the MPI_COMM_WORLD
+        communicator OR the MPI communicator to use. Given communicator will be duplicated.
+        If None, Horovod will use MPI_COMM_WORLD Communicator.
 
     """
     if comm is None:
         comm=[]
+
+    atexit.register(terminate, finalize=True)
 
     if not isinstance(comm, list):
         from mpi4py import MPI
@@ -75,8 +77,6 @@ def init(comm=None):
 
 def terminate(finalize=False):
     return MPI_COMMON_LIB_CTYPES.horovod_terminate(ctypes.c_bool(finalize))
-
-atexit.register(terminate, finalize=True)
 
 def size():
     """A function that returns the number of Horovod processes.

--- a/horovod/common/operations.cc
+++ b/horovod/common/operations.cc
@@ -1331,6 +1331,9 @@ void BackgroundThreadLoop(HorovodGlobalState& state) {
     }
     MPI_Group_free(&world_group);
     MPI_Group_free(&work_group);
+  } else if (!state.mpi_comm) {
+    // No ranks were given and no communicator provided to horovod_init() so use MPI_COMM_WORLD 
+    MPI_Comm_dup(MPI_COMM_WORLD, &(horovod_global.mpi_comm));
   }
 
   // Get MPI rank to determine if we are rank zero.

--- a/horovod/common/operations.cc
+++ b/horovod/common/operations.cc
@@ -1727,6 +1727,9 @@ void horovod_terminate(bool finalize) {
   if (horovod_global.background_thread.joinable()) {
     horovod_global.shut_down = true;
     horovod_global.background_thread.join();
+    // Reset the initialization flag to allow restarting with horovod_init(...)
+    horovod_global.initialize_flag.clear();
+    horovod_global.shut_down = false;
   }
 
   if (horovod_global.mpi_comm != MPI_COMM_WORLD) {

--- a/horovod/common/operations.cc
+++ b/horovod/common/operations.cc
@@ -1319,6 +1319,12 @@ void BackgroundThreadLoop(HorovodGlobalState& state) {
   MPI_Initialized(&is_mpi_initialized);
   if (is_mpi_initialized) {
     MPI_Query_thread(&provided);
+    if (provided < MPI_THREAD_MULTIPLE) {
+      std::cerr << "WARNING: MPI has already been initialized without "
+                   "multi-threading support (MPI_THREAD_MULTIPLE). This will "
+                   "likely cause a segmentation fault."
+                << std::endl;
+    }
   } else {
     MPI_Init_thread(NULL, NULL, required, &provided);
     state.should_finalize = true;

--- a/horovod/common/operations.h
+++ b/horovod/common/operations.h
@@ -52,7 +52,10 @@ Status CheckInitialized();
 extern "C" {
 
 // C interface to initialize Horovod.
-void horovod_init();
+void horovod_init(const int *ranks, int nranks);
+
+// C interface to terminate Horovod.
+void horovod_terminate(bool finalize);
 
 // C interface to get index of current Horovod process.
 // Returns -1 if Horovod is not initialized.

--- a/horovod/common/operations.h
+++ b/horovod/common/operations.h
@@ -59,8 +59,8 @@ void horovod_init(const int *ranks, int nranks);
 // C interface to initialize Horovod with the given MPI communicator.
 void horovod_init_comm(MPI_Comm comm);
 
-// C interface to terminate Horovod.
-void horovod_terminate(bool finalize);
+// C interface to shut down Horovod.
+void horovod_shutdown(bool finalize);
 
 // C interface to get index of current Horovod process.
 // Returns -1 if Horovod is not initialized.

--- a/horovod/common/operations.h
+++ b/horovod/common/operations.h
@@ -60,7 +60,7 @@ void horovod_init(const int *ranks, int nranks);
 void horovod_init_comm(MPI_Comm comm);
 
 // C interface to shut down Horovod.
-void horovod_shutdown(bool finalize);
+void horovod_shutdown();
 
 // C interface to get index of current Horovod process.
 // Returns -1 if Horovod is not initialized.

--- a/horovod/common/operations.h
+++ b/horovod/common/operations.h
@@ -19,6 +19,8 @@
 #include <functional>
 
 #include "common.h"
+#define OMPI_SKIP_MPICXX
+#include "mpi.h"
 
 namespace horovod {
 namespace common {
@@ -53,6 +55,9 @@ extern "C" {
 
 // C interface to initialize Horovod.
 void horovod_init(const int *ranks, int nranks);
+
+// C interface to initialize Horovod with the given MPI communicator.
+void horovod_init_comm(MPI_Comm comm);
 
 // C interface to terminate Horovod.
 void horovod_terminate(bool finalize);

--- a/horovod/keras/__init__.py
+++ b/horovod/keras/__init__.py
@@ -18,7 +18,7 @@ import tensorflow as tf
 
 import horovod.tensorflow as hvd
 from horovod.common import init
-from horovod.common import terminate
+from horovod.common import shutdown
 from horovod.common import size
 from horovod.common import local_size
 from horovod.common import rank

--- a/horovod/keras/__init__.py
+++ b/horovod/keras/__init__.py
@@ -18,6 +18,7 @@ import tensorflow as tf
 
 import horovod.tensorflow as hvd
 from horovod.common import init
+from horovod.common import terminate
 from horovod.common import size
 from horovod.common import local_size
 from horovod.common import rank

--- a/horovod/tensorflow/__init__.py
+++ b/horovod/tensorflow/__init__.py
@@ -30,6 +30,7 @@ from __future__ import division
 from __future__ import print_function
 
 from horovod.common import init
+from horovod.common import shutdown
 from horovod.common import size
 from horovod.common import local_size
 from horovod.common import rank

--- a/horovod/torch/__init__.py
+++ b/horovod/torch/__init__.py
@@ -18,6 +18,7 @@ from __future__ import division
 from __future__ import print_function
 
 from horovod.common import init
+from horovod.common import shutdown
 from horovod.common import size
 from horovod.common import local_size
 from horovod.common import rank


### PR DESCRIPTION
This enables users to initialize Horovod on a specified list of ranks or a given communicator. It allows multiple Horovod instances to be embedded in a larger MPI application. Very similar to the existing (stale) #218  