### PR TITLE
Support incompatible TensorFlow and PyTorch ABI

### DIFF
--- a/horovod/common/__init__.py
+++ b/horovod/common/__init__.py
@@ -33,121 +33,120 @@ def get_ext_suffix():
     return '.so'
 
 
-def check_extension(ext_name, ext_env_var, pkg_path, *args):
+def extension_full_path(pkg_path, *args):
     assert len(args) >= 1
     dir_path = os.path.join(os.path.dirname(pkg_path), *args[:-1])
     full_path = os.path.join(dir_path, args[-1] + get_ext_suffix())
+    return full_path
+
+
+def check_extension(ext_name, ext_env_var, pkg_path, *args):
+    full_path = extension_full_path(pkg_path, *args)
     if not os.path.exists(full_path):
         raise ImportError(
             'Extension %s has not been built.  If this is not expected, reinstall '
             'Horovod with %s=1 to debug the build error.' % (ext_name, ext_env_var))
 
 
-MPI_COMMON_LIB_CTYPES = \
-    ctypes.CDLL(os.path.join(os.path.dirname(__file__),
-                             'mpi_lib' + get_ext_suffix()), mode=ctypes.RTLD_GLOBAL)
+class HorovodExtension(object):
+    def __init__(self, pkg_path, *args):
+        full_path = extension_full_path(pkg_path, *args)
+        self.MPI_LIB_CTYPES = ctypes.CDLL(full_path, mode=ctypes.RTLD_GLOBAL)
 
+    def init(self, comm=None):
+        """A function that initializes Horovod.
 
-def init(comm=None):
-    """A function that initializes Horovod.
+        Args:
+          comm: List specifying ranks for the communicator, relative to the MPI_COMM_WORLD
+            communicator OR the MPI communicator to use. Given communicator will be duplicated.
+            If None, Horovod will use MPI_COMM_WORLD Communicator.
 
-    Args:
-      comm: List specifying ranks for the communicator, relative to the MPI_COMM_WORLD
-        communicator OR the MPI communicator to use. Given communicator will be duplicated.
-        If None, Horovod will use MPI_COMM_WORLD Communicator.
+        """
+        if comm is None:
+            comm = []
 
-    """
-    if comm is None:
-        comm = []
+        atexit.register(self.shutdown)
 
-    atexit.register(shutdown)
+        if not isinstance(comm, list):
+            from mpi4py import MPI
+            if MPI._sizeof(MPI.Comm) == ctypes.sizeof(ctypes.c_int):
+                MPI_Comm = ctypes.c_int
+            else:
+                MPI_Comm = ctypes.c_void_p
+                self.MPI_LIB_CTYPES.horovod_init_comm.argtypes = [MPI_Comm]
 
-    if not isinstance(comm, list):
-        from mpi4py import MPI
-        if MPI._sizeof(MPI.Comm) == ctypes.sizeof(ctypes.c_int):
-            MPI_Comm = ctypes.c_int
+            comm_obj = MPI_Comm.from_address(MPI._addressof(comm))
+            return self.MPI_LIB_CTYPES.horovod_init_comm(comm_obj)
         else:
-            MPI_Comm = ctypes.c_void_p
-            MPI_COMMON_LIB_CTYPES.horovod_init_comm.argtypes = [MPI_Comm]
+            comm_size = len(comm)
+            return self.MPI_LIB_CTYPES.horovod_init(
+                (ctypes.c_int * comm_size)(*comm), ctypes.c_int(comm_size))
 
-        comm_obj = MPI_Comm.from_address(MPI._addressof(comm))
-        return MPI_COMMON_LIB_CTYPES.horovod_init_comm(comm_obj)
-    else:
-        comm_size = len(comm)
-        return MPI_COMMON_LIB_CTYPES.horovod_init(
-            (ctypes.c_int * comm_size)(*comm), ctypes.c_int(comm_size))
+    def shutdown(self):
+        return self.MPI_LIB_CTYPES.horovod_shutdown()
 
+    def size(self):
+        """A function that returns the number of Horovod processes.
 
-def shutdown():
-    return MPI_COMMON_LIB_CTYPES.horovod_shutdown()
+        Returns:
+          An integer scalar containing the number of Horovod processes.
+        """
+        size = self.MPI_LIB_CTYPES.horovod_size()
+        if size == -1:
+            raise ValueError(
+                'Horovod has not been initialized; use hvd.init().')
+        return size
 
+    def local_size(self):
+        """A function that returns the number of Horovod processes within the
+        node the current process is running on.
 
-def size():
-    """A function that returns the number of Horovod processes.
+        Returns:
+          An integer scalar containing the number of local Horovod processes.
+        """
+        local_size = self.MPI_LIB_CTYPES.horovod_local_size()
+        if local_size == -1:
+            raise ValueError(
+                'Horovod has not been initialized; use hvd.init().')
+        return local_size
 
-    Returns:
-      An integer scalar containing the number of Horovod processes.
-    """
-    size = MPI_COMMON_LIB_CTYPES.horovod_size()
-    if size == -1:
-        raise ValueError(
-            'Horovod has not been initialized; use hvd.init().')
-    return size
+    def rank(self):
+        """A function that returns the Horovod rank of the calling process.
 
+        Returns:
+          An integer scalar with the Horovod rank of the calling process.
+        """
+        rank = self.MPI_LIB_CTYPES.horovod_rank()
+        if rank == -1:
+            raise ValueError(
+                'Horovod has not been initialized; use hvd.init().')
+        return rank
 
-def local_size():
-    """A function that returns the number of Horovod processes within the
-    node the current process is running on.
+    def local_rank(self):
+        """A function that returns the local Horovod rank of the calling process, within the
+        node that it is running on. For example, if there are seven processes running
+        on a node, their local ranks will be zero through six, inclusive.
 
-    Returns:
-      An integer scalar containing the number of local Horovod processes.
-    """
-    local_size = MPI_COMMON_LIB_CTYPES.horovod_local_size()
-    if local_size == -1:
-        raise ValueError(
-            'Horovod has not been initialized; use hvd.init().')
-    return local_size
+        Returns:
+          An integer scalar with the local Horovod rank of the calling process.
+        """
+        local_rank = self.MPI_LIB_CTYPES.horovod_local_rank()
+        if local_rank == -1:
+            raise ValueError(
+                'Horovod has not been initialized; use hvd.init().')
+        return local_rank
 
+    def mpi_threads_supported(self):
+        """A function that returns a flag indicating whether MPI multi-threading is supported.
 
-def rank():
-    """A function that returns the Horovod rank of the calling process.
+        If MPI multi-threading is supported, users may mix and match Horovod usage with other
+        MPI libraries, such as `mpi4py`.
 
-    Returns:
-      An integer scalar with the Horovod rank of the calling process.
-    """
-    rank = MPI_COMMON_LIB_CTYPES.horovod_rank()
-    if rank == -1:
-        raise ValueError(
-            'Horovod has not been initialized; use hvd.init().')
-    return rank
-
-
-def local_rank():
-    """A function that returns the local Horovod rank of the calling process, within the
-    node that it is running on. For example, if there are seven processes running
-    on a node, their local ranks will be zero through six, inclusive.
-
-    Returns:
-      An integer scalar with the local Horovod rank of the calling process.
-    """
-    local_rank = MPI_COMMON_LIB_CTYPES.horovod_local_rank()
-    if local_rank == -1:
-        raise ValueError(
-            'Horovod has not been initialized; use hvd.init().')
-    return local_rank
-
-
-def mpi_threads_supported():
-    """A function that returns a flag indicating whether MPI multi-threading is supported.
-
-    If MPI multi-threading is supported, users may mix and match Horovod usage with other
-    MPI libraries, such as `mpi4py`.
-
-    Returns:
-      A boolean value indicating whether MPI multi-threading is supported.
-    """
-    mpi_threads_supported = MPI_COMMON_LIB_CTYPES.horovod_mpi_threads_supported()
-    if mpi_threads_supported == -1:
-        raise ValueError(
-            'Horovod has not been initialized; use hvd.init().')
-    return bool(mpi_threads_supported)
+        Returns:
+          A boolean value indicating whether MPI multi-threading is supported.
+        """
+        mpi_threads_supported = self.MPI_LIB_CTYPES.horovod_mpi_threads_supported()
+        if mpi_threads_supported == -1:
+            raise ValueError(
+                'Horovod has not been initialized; use hvd.init().')
+        return bool(mpi_threads_supported)

--- a/horovod/common/__init__.py
+++ b/horovod/common/__init__.py
@@ -48,7 +48,7 @@ def check_extension(ext_name, ext_env_var, pkg_path, *args):
             'Horovod with %s=1 to debug the build error.' % (ext_name, ext_env_var))
 
 
-class HorovodExtension(object):
+class HorovodBasics(object):
     def __init__(self, pkg_path, *args):
         full_path = extension_full_path(pkg_path, *args)
         self.MPI_LIB_CTYPES = ctypes.CDLL(full_path, mode=ctypes.RTLD_GLOBAL)

--- a/horovod/common/__init__.py
+++ b/horovod/common/__init__.py
@@ -49,6 +49,8 @@ def check_extension(ext_name, ext_env_var, pkg_path, *args):
 
 
 class HorovodBasics(object):
+    """Wrapper class for the basic Horovod API."""
+
     def __init__(self, pkg_path, *args):
         full_path = extension_full_path(pkg_path, *args)
         self.MPI_LIB_CTYPES = ctypes.CDLL(full_path, mode=ctypes.RTLD_GLOBAL)
@@ -60,7 +62,6 @@ class HorovodBasics(object):
           comm: List specifying ranks for the communicator, relative to the MPI_COMM_WORLD
             communicator OR the MPI communicator to use. Given communicator will be duplicated.
             If None, Horovod will use MPI_COMM_WORLD Communicator.
-
         """
         if comm is None:
             comm = []
@@ -83,6 +84,7 @@ class HorovodBasics(object):
                 (ctypes.c_int * comm_size)(*comm), ctypes.c_int(comm_size))
 
     def shutdown(self):
+        """A function that shuts Horovod down."""
         return self.MPI_LIB_CTYPES.horovod_shutdown()
 
     def size(self):

--- a/horovod/common/__init__.py
+++ b/horovod/common/__init__.py
@@ -33,7 +33,7 @@ def get_ext_suffix():
     return '.so'
 
 
-def extension_full_path(pkg_path, *args):
+def get_extension_full_path(pkg_path, *args):
     assert len(args) >= 1
     dir_path = os.path.join(os.path.dirname(pkg_path), *args[:-1])
     full_path = os.path.join(dir_path, args[-1] + get_ext_suffix())
@@ -41,7 +41,7 @@ def extension_full_path(pkg_path, *args):
 
 
 def check_extension(ext_name, ext_env_var, pkg_path, *args):
-    full_path = extension_full_path(pkg_path, *args)
+    full_path = get_extension_full_path(pkg_path, *args)
     if not os.path.exists(full_path):
         raise ImportError(
             'Extension %s has not been built.  If this is not expected, reinstall '
@@ -52,7 +52,7 @@ class HorovodBasics(object):
     """Wrapper class for the basic Horovod API."""
 
     def __init__(self, pkg_path, *args):
-        full_path = extension_full_path(pkg_path, *args)
+        full_path = get_extension_full_path(pkg_path, *args)
         self.MPI_LIB_CTYPES = ctypes.CDLL(full_path, mode=ctypes.RTLD_GLOBAL)
 
     def init(self, comm=None):

--- a/horovod/keras/__init__.py
+++ b/horovod/keras/__init__.py
@@ -17,13 +17,13 @@ import keras.backend as K
 import tensorflow as tf
 
 import horovod.tensorflow as hvd
-from horovod.common import init
-from horovod.common import shutdown
-from horovod.common import size
-from horovod.common import local_size
-from horovod.common import rank
-from horovod.common import local_rank
-from horovod.common import mpi_threads_supported
+from horovod.tensorflow import init
+from horovod.tensorflow import shutdown
+from horovod.tensorflow import size
+from horovod.tensorflow import local_size
+from horovod.tensorflow import rank
+from horovod.tensorflow import local_rank
+from horovod.tensorflow import mpi_threads_supported
 from horovod.keras import callbacks
 
 

--- a/horovod/tensorflow/__init__.py
+++ b/horovod/tensorflow/__init__.py
@@ -29,20 +29,14 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-from horovod.common import init
-from horovod.common import shutdown
-from horovod.common import size
-from horovod.common import local_size
-from horovod.common import rank
-from horovod.common import local_rank
-from horovod.common import mpi_threads_supported
 from horovod.common import check_extension
 
 check_extension('horovod.tensorflow', 'HOROVOD_WITH_TENSORFLOW', __file__, 'mpi_lib')
 
-from horovod.tensorflow.mpi_ops import allgather
-from horovod.tensorflow.mpi_ops import broadcast
-from horovod.tensorflow.mpi_ops import _allreduce
+from horovod.tensorflow.mpi_ops import allgather, broadcast, _allreduce
+from horovod.tensorflow.mpi_ops import init, shutdown
+from horovod.tensorflow.mpi_ops import size, local_size, rank, local_rank
+from horovod.tensorflow.mpi_ops import mpi_threads_supported
 
 import tensorflow as tf
 

--- a/horovod/tensorflow/mpi_ops.py
+++ b/horovod/tensorflow/mpi_ops.py
@@ -26,7 +26,7 @@ from tensorflow.python.framework import ops
 from tensorflow.python.platform import resource_loader
 
 from horovod.common import get_ext_suffix
-from horovod.common import HorovodExtension as _HorovodExtension
+from horovod.common import HorovodBasics as _HorovodBasics
 
 
 def _load_library(name, op_list=None):
@@ -57,16 +57,16 @@ def _load_library(name, op_list=None):
 MPI_LIB = _load_library('mpi_lib' + get_ext_suffix(),
                         ['HorovodAllgather', 'HorovodAllreduce'])
 
-_ext = _HorovodExtension(__file__, 'mpi_lib')
+_basics = _HorovodBasics(__file__, 'mpi_lib')
 
-# import common methods
-init = _ext.init
-shutdown = _ext.shutdown
-size = _ext.size
-local_size = _ext.local_size
-rank = _ext.rank
-local_rank = _ext.local_rank
-mpi_threads_supported = _ext.mpi_threads_supported
+# import basic methods
+init = _basics.init
+shutdown = _basics.shutdown
+size = _basics.size
+local_size = _basics.local_size
+rank = _basics.rank
+local_rank = _basics.local_rank
+mpi_threads_supported = _basics.mpi_threads_supported
 
 
 def _normalize_name(name):

--- a/horovod/tensorflow/mpi_ops.py
+++ b/horovod/tensorflow/mpi_ops.py
@@ -25,7 +25,8 @@ from tensorflow.python.framework import load_library
 from tensorflow.python.framework import ops
 from tensorflow.python.platform import resource_loader
 
-from horovod.common import get_ext_suffix, rank, size
+from horovod.common import get_ext_suffix
+from horovod.common import HorovodExtension as _HorovodExtension
 
 
 def _load_library(name, op_list=None):
@@ -55,6 +56,17 @@ def _load_library(name, op_list=None):
 
 MPI_LIB = _load_library('mpi_lib' + get_ext_suffix(),
                         ['HorovodAllgather', 'HorovodAllreduce'])
+
+_ext = _HorovodExtension(__file__, 'mpi_lib')
+
+# import common methods
+init = _ext.init
+shutdown = _ext.shutdown
+size = _ext.size
+local_size = _ext.local_size
+rank = _ext.rank
+local_rank = _ext.local_rank
+mpi_threads_supported = _ext.mpi_threads_supported
 
 
 def _normalize_name(name):

--- a/horovod/torch/__init__.py
+++ b/horovod/torch/__init__.py
@@ -17,13 +17,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-from horovod.common import init
-from horovod.common import shutdown
-from horovod.common import size
-from horovod.common import local_size
-from horovod.common import rank
-from horovod.common import local_rank
-from horovod.common import mpi_threads_supported
 from horovod.common import check_extension
 
 check_extension('horovod.torch', 'HOROVOD_WITH_PYTORCH',
@@ -33,6 +26,9 @@ from horovod.torch.mpi_ops import allreduce, allreduce_async, allreduce_, allred
 from horovod.torch.mpi_ops import allgather, allgather_async
 from horovod.torch.mpi_ops import broadcast, broadcast_async, broadcast_, broadcast_async_
 from horovod.torch.mpi_ops import poll, synchronize
+from horovod.torch.mpi_ops import init, shutdown
+from horovod.torch.mpi_ops import size, local_size, rank, local_rank
+from horovod.torch.mpi_ops import mpi_threads_supported
 
 import torch
 import collections

--- a/horovod/torch/mpi_ops.py
+++ b/horovod/torch/mpi_ops.py
@@ -22,7 +22,18 @@ import torch
 
 from horovod.torch import mpi_lib_impl
 from horovod.torch import mpi_lib
-from horovod.torch import rank, size
+from horovod.common import HorovodExtension as _HorovodExtension
+
+_ext = _HorovodExtension(__file__, 'mpi_lib_impl', '_mpi_lib_impl')
+
+# import common methods
+init = _ext.init
+shutdown = _ext.shutdown
+size = _ext.size
+local_size = _ext.local_size
+rank = _ext.rank
+local_rank = _ext.local_rank
+mpi_threads_supported = _ext.mpi_threads_supported
 
 
 # Schema: handle -> input, output

--- a/horovod/torch/mpi_ops.py
+++ b/horovod/torch/mpi_ops.py
@@ -22,18 +22,18 @@ import torch
 
 from horovod.torch import mpi_lib_impl
 from horovod.torch import mpi_lib
-from horovod.common import HorovodExtension as _HorovodExtension
+from horovod.common import HorovodBasics as _HorovodBasics
 
-_ext = _HorovodExtension(__file__, 'mpi_lib_impl', '_mpi_lib_impl')
+_basics = _HorovodBasics(__file__, 'mpi_lib_impl', '_mpi_lib_impl')
 
-# import common methods
-init = _ext.init
-shutdown = _ext.shutdown
-size = _ext.size
-local_size = _ext.local_size
-rank = _ext.rank
-local_rank = _ext.local_rank
-mpi_threads_supported = _ext.mpi_threads_supported
+# import basic methods
+init = _basics.init
+shutdown = _basics.shutdown
+size = _basics.size
+local_size = _basics.local_size
+rank = _basics.rank
+local_rank = _basics.local_rank
+mpi_threads_supported = _basics.mpi_threads_supported
 
 
 # Schema: handle -> input, output

--- a/test/common.py
+++ b/test/common.py
@@ -20,8 +20,6 @@ from __future__ import print_function
 
 import os
 
-import horovod.common as hvd
-
 
 def mpi_env_rank_and_size():
     """Get MPI rank and size from environment variables and return them as a
@@ -56,19 +54,3 @@ def mpi_env_rank_and_size():
 
     # Default to rank zero and size one if there are no environment variables
     return 0, 1
-
-
-def test_horovod_rank():
-    """Test that the rank returned by hvd.rank() is correct."""
-    true_rank, _ = mpi_env_rank_and_size()
-    hvd.init()
-    rank = hvd.rank()
-    assert true_rank == rank
-
-
-def test_horovod_size():
-    """Test that the size returned by hvd.size() is correct."""
-    _, true_size = mpi_env_rank_and_size()
-    hvd.init()
-    size = hvd.size()
-    assert true_size == size

--- a/test/test_tensorflow.py
+++ b/test/test_tensorflow.py
@@ -26,6 +26,8 @@ import tensorflow as tf
 
 import horovod.tensorflow as hvd
 
+from common import mpi_env_rank_and_size
+
 
 class MPITests(tf.test.TestCase):
     """
@@ -36,6 +38,20 @@ class MPITests(tf.test.TestCase):
         super(MPITests, self).__init__(*args, **kwargs)
         self.config = tf.ConfigProto()
         self.config.gpu_options.allow_growth = True
+
+    def test_horovod_rank(self):
+        """Test that the rank returned by hvd.rank() is correct."""
+        true_rank, _ = mpi_env_rank_and_size()
+        hvd.init()
+        rank = hvd.rank()
+        assert true_rank == rank
+
+    def test_horovod_size(self):
+        """Test that the size returned by hvd.size() is correct."""
+        _, true_size = mpi_env_rank_and_size()
+        hvd.init()
+        size = hvd.size()
+        assert true_size == size
 
     def test_horovod_allreduce_cpu(self):
         """Test on CPU that the allreduce correctly sums 1D, 2D, 3D tensors."""

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -28,11 +28,27 @@ import numpy as np
 
 import horovod.torch as hvd
 
+from common import mpi_env_rank_and_size
+
 
 class TorchTests(unittest.TestCase):
     """
     Tests for ops in horovod.torch.
     """
+
+    def test_horovod_rank(self):
+        """Test that the rank returned by hvd.rank() is correct."""
+        true_rank, _ = mpi_env_rank_and_size()
+        hvd.init()
+        rank = hvd.rank()
+        assert true_rank == rank
+
+    def test_horovod_size(self):
+        """Test that the size returned by hvd.size() is correct."""
+        _, true_size = mpi_env_rank_and_size()
+        hvd.init()
+        size = hvd.size()
+        assert true_size == size
 
     def test_horovod_allreduce(self):
         """Test that the allreduce correctly sums 1D, 2D, 3D tensors."""


### PR DESCRIPTION
Split off `horovod.common` C++ code compilation into both `horovod.tensorflow` and `horovod.torch`.  Preparation for migrating PyTorch plugin to C++.

**Note:** You can still import both `horovod.tensorflow` and `horovod.torch` into the same Python script, but they will create two separate MPI communicators and background threads.