### PR TITLE
Fix torch_nightly test to not use `torch`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -84,7 +84,9 @@ install:
   # PyTorch
   - |
     if [[ ${PYTORCH_PACKAGE} == "torch-nightly" ]]; then
-      docker exec ${CONTAINER} /bin/sh -c "pip install torch_nightly torchvision -v -f https://download.pytorch.org/whl/nightly/cu90/torch_nightly.html"
+      docker exec ${CONTAINER} /bin/sh -c "pip install torchvision"
+      docker exec ${CONTAINER} /bin/sh -c "pip uninstall -y torch"
+      docker exec ${CONTAINER} /bin/sh -c "pip install torch_nightly -v -f https://download.pytorch.org/whl/nightly/cu90/torch_nightly.html"
     else
       docker exec ${CONTAINER} /bin/sh -c "pip install ${PYTORCH_PACKAGE} torchvision"
     fi

--- a/setup.py
+++ b/setup.py
@@ -517,7 +517,7 @@ def is_torch_cuda_v2(build_ext, include_dirs, extra_compile_args):
             }
             '''))
         return True
-    except (CompileError, LinkError):
+    except (CompileError, LinkError, EnvironmentError):
         print('INFO: Above error indicates that this PyTorch installation does not support CUDA.')
         return False
 


### PR DESCRIPTION
`pip install torch_nightly torchvision` brings in `torch` as well.