### PR TITLE
Use MPI_Type_size to get sizes of MPI types

### DIFF
--- a/horovod/common/operations.cc
+++ b/horovod/common/operations.cc
@@ -1009,7 +1009,8 @@ void PerformOperation(TensorTable& tensor_table, MPIResponse response) {
                               DDL_OP_SUM))
 #else
       if (horovod_global.hierarchical_allreduce) {
-        int element_size = buffer_len / num_elements;
+        int element_size;
+        MPI_Type_size(GetMPIDataType(first_entry.tensor), &element_size); 
 
         // If cluster is homogeneous and we are using fusion buffer, include
         // dummy elements from the buffer (if necessary) to make sure the data
@@ -1571,7 +1572,9 @@ void BackgroundThreadLoop(HorovodGlobalState& state) {
 
     // Ensuring that fusion buffer can hold a number of elements divisible by
     // FUSION_BUFFER_ATOMIC_UNIT for performance
-    int64_t div = state.local_size * sizeof(MPI_DOUBLE) * FUSION_BUFFER_ATOMIC_UNIT;
+    int mpi_type_size;
+    MPI_Type_size(MPI_DOUBLE, &mpi_type_size);
+    int64_t div = state.local_size * mpi_type_size * FUSION_BUFFER_ATOMIC_UNIT;
     state.tensor_fusion_threshold = ((proposed_fusion_threshold+div-1) / div) * div;
   } else {
     state.tensor_fusion_threshold = proposed_fusion_threshold;

--- a/horovod/common/operations.cc
+++ b/horovod/common/operations.cc
@@ -1572,9 +1572,9 @@ void BackgroundThreadLoop(HorovodGlobalState& state) {
 
     // Ensuring that fusion buffer can hold a number of elements divisible by
     // FUSION_BUFFER_ATOMIC_UNIT for performance
-    int mpi_type_size;
-    MPI_Type_size(MPI_DOUBLE, &mpi_type_size);
-    int64_t div = state.local_size * mpi_type_size * FUSION_BUFFER_ATOMIC_UNIT;
+    int mpi_double_size;
+    MPI_Type_size(MPI_DOUBLE, &mpi_double_size);
+    int64_t div = state.local_size * mpi_double_size * FUSION_BUFFER_ATOMIC_UNIT;
     state.tensor_fusion_threshold = ((proposed_fusion_threshold+div-1) / div) * div;
   } else {
     state.tensor_fusion_threshold = proposed_fusion_threshold;


### PR DESCRIPTION
Use `MPI_Type_size` to get the size of MPI types instead of dividing `buffer_len` by `num_elements`, which may give division-by-zero errors for empty tensors, or using sizeof(MPI_DOUBLE), which does not have correct behavior.