### PR TITLE
Fixed issue with dynamically linking PyTorch module on Mac OSX 

### DIFF
--- a/horovod.exp
+++ b/horovod.exp
@@ -3,5 +3,5 @@
 *PyInit*
 initmpi_lib_v2
 # Legacy PyTorch binding
-init_mpi_lib
-init_mpi_lib_impl
+_init_mpi_lib
+_init_mpi_lib_impl

--- a/horovod.exp
+++ b/horovod.exp
@@ -1,7 +1,7 @@
 *horovod*
 # PyTorch binding
 *PyInit*
-initmpi_lib_v2
+*initmpi_lib_v2*
 # Legacy PyTorch binding
-_init_mpi_lib
-_init_mpi_lib_impl
+*init_mpi_lib*
+*init_mpi_lib_impl*

--- a/horovod.lds
+++ b/horovod.lds
@@ -3,9 +3,9 @@
     *horovod*;
     # PyTorch binding
     *PyInit*;
-    initmpi_lib_v2;
+    *initmpi_lib_v2*;
     # Legacy PyTorch binding
-    init_mpi_lib;
-    init_mpi_lib_impl;
+    *init_mpi_lib*;
+    *init_mpi_lib_impl*;
   local: *;
 };


### PR DESCRIPTION
due to hidden symbol