### PR TITLE
Fixed broadcast_optimizer_state for stateless optimizers

### DIFF
--- a/horovod/torch/__init__.py
+++ b/horovod/torch/__init__.py
@@ -193,6 +193,13 @@ def broadcast_optimizer_state(optimizer, root_rank):
         optimizer.step()
         state_dict = optimizer.state_dict()
 
+    # If the state_dict is still empty after initialization, then
+    # the optimizer is stateless, and there is nothing to broadcast.
+    # Furthermore, attempting to access the state dict would result in
+    # an error.
+    if len(state_dict['state']) == 0:
+        return
+
     params = []
     callbacks = {}
     occurrences = collections.defaultdict(int)


### PR DESCRIPTION
This resolves an issue very specific to SGD, which only maintains state when momentum is specified.  Without momentum, it's stateless, and attempting to access the state dict during broadcast raises an error.  This solution is to simply skip broadcast if the state dict is empty.