### PR TITLE
PyTorch 1.0: Switch to new way to initialize CPU tensors (v2)

### DIFF
--- a/horovod/torch/mpi_ops_v2.cc
+++ b/horovod/torch/mpi_ops_v2.cc
@@ -139,8 +139,7 @@ int DoAllgatherCudaOnCPU(at::Tensor tensor, at::Tensor output,
   auto hvd_cpu_tensor = std::make_shared<TorchTensor>(cpu_tensor);
   auto ready_event = RecordReadyEvent(device);
 
-  auto cpu_output =
-      at::tensor(cpu_tensor.type()).to(at::Device(at::DeviceType::CPU));
+  auto cpu_output = at::empty_like(cpu_tensor);
   auto hvd_cpu_output = std::make_shared<TorchTensor>(cpu_output);
   auto hvd_context =
       std::make_shared<TorchOpContext>(CPU_DEVICE_ID, cpu_output);


### PR DESCRIPTION
Inspired by https://github.com/pytorch/pytorch/pull/12360.  Improves on #555 by not creating brand new non-Variable Tensor.