### PR TITLE
Switch Horovod Shutdown to UnknownError

### DIFF
--- a/horovod/common/operations.cc
+++ b/horovod/common/operations.cc
@@ -253,7 +253,7 @@ HorovodGlobalState horovod_global;
 const Status NOT_INITIALIZED_ERROR = Status::PreconditionError(
     "Horovod has not been initialized; use hvd.init().");
 
-const Status SHUT_DOWN_ERROR = Status::Aborted(
+const Status SHUT_DOWN_ERROR = Status::UnknownError(
     "Horovod has been shut down. This was caused by an exception on one of the "
     "ranks or an attempt to allreduce, allgather or broadcast a tensor after "
     "one of the ranks finished execution. If the shutdown was caused by an "


### PR DESCRIPTION
TensorFlow treats AbortedError in a special way - it will do infinite retries in MonitedSession if AbortedError is encountered in the hook.  Switching to UnknownError should prevent this retry logic.

Fixes #552 