### PR TITLE
Added option to treat sparse gradients as dense tensors

### DIFF
--- a/horovod/keras/__init__.py
+++ b/horovod/keras/__init__.py
@@ -31,7 +31,8 @@ from horovod.keras import impl as _impl
 
 def DistributedOptimizer(optimizer, name=None,
                          device_dense='', device_sparse='',
-                         compression=Compression.none):
+                         compression=Compression.none,
+                         sparse_as_dense=False):
     """
     An optimizer that wraps another keras.optimizers.Optimizer, using an allreduce to
     average gradient values before applying gradients to model weights.
@@ -48,9 +49,14 @@ def DistributedOptimizer(optimizer, name=None,
         compression: Compression algorithm used to reduce the amount of data
                      sent and received by each worker node.  Defaults to not
                      using compression.
+        sparse_as_dense: Treat all sparse gradients as dense tensors.  This can
+                         help improve performance and memory utilization if
+                         the original sparse gradient has high density.
+                         Defaults to false.
     """
     return _impl.create_distributed_optimizer(keras, optimizer, name,
-                                              device_dense, device_sparse, compression)
+                                              device_dense, device_sparse, compression,
+                                              sparse_as_dense)
 
 
 def broadcast_global_variables(root_rank):

--- a/horovod/keras/impl.py
+++ b/horovod/keras/impl.py
@@ -17,15 +17,18 @@ import horovod.tensorflow as hvd
 import tensorflow as tf
 
 
-def create_distributed_optimizer(keras, optimizer, name, device_dense, device_sparse, compression):
+def create_distributed_optimizer(keras, optimizer, name, device_dense, device_sparse,
+                                 compression, sparse_as_dense):
     class _DistributedOptimizer(keras.optimizers.Optimizer):
-        def __init__(self, name, device_dense, device_sparse, **kwargs):
+        def __init__(self, name, device_dense, device_sparse, compression, sparse_as_dense,
+                     **kwargs):
             if name is None:
                 name = "Distributed%s" % self.__class__.__base__.__name__
             self._name = name
             self._device_dense = device_dense
             self._device_sparse = device_sparse
             self._compression = compression
+            self._sparse_as_dense = sparse_as_dense
             super(self.__class__, self).__init__(**kwargs)
 
         def get_gradients(self, loss, params):
@@ -43,6 +46,9 @@ def create_distributed_optimizer(keras, optimizer, name, device_dense, device_sp
                 with tf.name_scope(self._name + "_Allreduce"):
                     for grad in gradients:
                         if grad is not None:
+                            if self._sparse_as_dense and \
+                                    isinstance(grad, tf.IndexedSlices):
+                                grad = tf.convert_to_tensor(grad)
                             avg_grad = hvd.allreduce(grad,
                                                      device_dense=self._device_dense,
                                                      device_sparse=self._device_sparse,
@@ -60,7 +66,8 @@ def create_distributed_optimizer(keras, optimizer, name, device_dense, device_sp
     # model could be easily restored without Horovod.
     cls = type(optimizer.__class__.__name__, (optimizer.__class__,),
                dict(_DistributedOptimizer.__dict__))
-    return cls(name, device_dense, device_sparse, **optimizer.get_config())
+    return cls(name, device_dense, device_sparse, compression, sparse_as_dense,
+               **optimizer.get_config())
 
 
 def broadcast_global_variables(backend, root_rank):

--- a/horovod/tensorflow/__init__.py
+++ b/horovod/tensorflow/__init__.py
@@ -137,7 +137,8 @@ class DistributedOptimizer(tf.train.Optimizer):
     average gradient values before applying gradients to model weights."""
 
     def __init__(self, optimizer, name=None, use_locking=False, device_dense='',
-                 device_sparse='', compression=Compression.none):
+                 device_sparse='', compression=Compression.none,
+                 sparse_as_dense=False):
         """Construct a new DistributedOptimizer, which uses another optimizer
         under the hood for computing single-process gradient values and
         applying gradient updates after the gradient values have been averaged
@@ -163,6 +164,10 @@ class DistributedOptimizer(tf.train.Optimizer):
             Compression algorithm used during allreduce to reduce the amount
             of data sent during the each parameter update step.  Defaults to
             not using compression.
+          sparse_as_dense:
+            Treat all sparse gradients as dense tensors.  This can help improve
+            performance and memory utilization if the original sparse gradient
+            has high density.  Defaults to false.
         """
         if name is None:
             name = "Distributed{}".format(type(optimizer).__name__)
@@ -171,6 +176,7 @@ class DistributedOptimizer(tf.train.Optimizer):
         self._device_dense = device_dense
         self._device_sparse = device_sparse
         self._compression = compression
+        self._sparse_as_dense = sparse_as_dense
         super(DistributedOptimizer, self).__init__(
             name=name, use_locking=use_locking)
 
@@ -188,6 +194,9 @@ class DistributedOptimizer(tf.train.Optimizer):
             with tf.name_scope(self._name + "_Allreduce"):
                 for grad, var in gradients:
                     if grad is not None:
+                        if self._sparse_as_dense and \
+                                isinstance(grad, tf.IndexedSlices):
+                            grad = tf.convert_to_tensor(grad)
                         avg_grad = allreduce(grad,
                                              device_dense=self._device_dense,
                                              device_sparse=self._device_sparse,

--- a/horovod/tensorflow/keras/__init__.py
+++ b/horovod/tensorflow/keras/__init__.py
@@ -38,7 +38,8 @@ from horovod.tensorflow.keras import callbacks
 
 def DistributedOptimizer(optimizer, name=None,
                          device_dense='', device_sparse='',
-                         compression=Compression.none):
+                         compression=Compression.none,
+                         sparse_as_dense=False):
     """
     An optimizer that wraps another keras.optimizers.Optimizer, using an allreduce to
     average gradient values before applying gradients to model weights.
@@ -55,9 +56,13 @@ def DistributedOptimizer(optimizer, name=None,
         compression: Compression algorithm used to reduce the amount of data
                      sent and received by each worker node.  Defaults to not
                      using compression.
-    """
+        sparse_as_dense: Treat all sparse gradients as dense tensors.  This can
+                         help improve performance and memory utilization if
+                         the original sparse gradient has high density.
+                         Defaults to false.    """
     return _impl.create_distributed_optimizer(keras, optimizer, name,
-                                              device_dense, device_sparse, compression)
+                                              device_dense, device_sparse, compression,
+                                              sparse_as_dense)
 
 
 def broadcast_global_variables(root_rank):

--- a/test/test_tensorflow_keras.py
+++ b/test/test_tensorflow_keras.py
@@ -75,3 +75,22 @@ class TfKerasTests(tf.test.TestCase):
                                 verbose=0,
                                 workers=4,
                                 initial_epoch=1)
+
+    def test_sparse_as_dense(self):
+        hvd.init()
+
+        with self.test_session() as sess:
+            K.set_session(sess)
+
+            opt = keras.optimizers.RMSprop(lr=0.0001)
+            opt = hvd.DistributedOptimizer(opt, sparse_as_dense=True)
+
+            model = keras.models.Sequential()
+            model.add(keras.layers.Embedding(1000, 64, input_length=10))
+            model.compile(loss=keras.losses.MSE,
+                          optimizer=opt)
+
+            x = np.random.randint(1000, size=(32, 10))
+            y = np.random.random((32, 10, 64))
+            # No assertions, we just need to verify that it doesn't hang
+            model.train_on_batch(x, y)

--- a/test/test_tensorflow_keras.py
+++ b/test/test_tensorflow_keras.py
@@ -87,7 +87,7 @@ class TfKerasTests(tf.test.TestCase):
 
             model = keras.models.Sequential()
             model.add(keras.layers.Embedding(1000, 64, input_length=10))
-            model.compile(loss=keras.losses.MSE,
+            model.compile(loss=keras.losses.mean_squared_error,
                           optimizer=opt)
 
             x = np.random.randint(1000, size=(32, 10))


### PR DESCRIPTION
As shown in #554, #566, #430, and potentially other issues, sometimes sparse gradients are not so sparse.  This can cause bad performance and OOMs.

This change introduces option `hvd.DistributedOptimizer(..., sparse_as_dense=False)` that, if set to true, will force all sparse gradients to be densified.

Fixes #554 
Fixes #566 
Fixes #430