### PR TITLE
PyTorch break: .dtype() -> .scalar_type()

### DIFF
--- a/horovod/torch/adapter_v2.cc
+++ b/horovod/torch/adapter_v2.cc
@@ -37,7 +37,7 @@ TorchPersistentBuffer::AccessData(std::shared_ptr<OpContext> context) const {
 TorchTensor::TorchTensor(at::Tensor tensor) : tensor_(tensor) {}
 
 const MPIDataType TorchTensor::dtype() const {
-  switch (tensor_.dtype()) {
+  switch (tensor_.scalar_type()) {
   case at::ScalarType::Byte:
     return common::HOROVOD_UINT8;
   case at::ScalarType::Char:


### PR DESCRIPTION
Details are in https://github.com/pytorch/pytorch/pull/12766