### PR TITLE
Use torch:: instead of at:: namespace in Torch backend

### DIFF
--- a/horovod/torch/adapter_v2.cc
+++ b/horovod/torch/adapter_v2.cc
@@ -23,9 +23,9 @@ TorchPersistentBuffer::TorchPersistentBuffer(int device, int64_t size)
     : device_(device) {
   with_device device_context(device_);
   if (device_ == CPU_DEVICE_ID) {
-    tensor_ = torch::empty(size, torch::device(torch::kCPU).dtype(torch::kByte));
+    tensor_ = ::torch::empty(size, ::torch::device(::torch::kCPU).dtype(::torch::kByte));
   } else {
-    tensor_ = torch::empty(size, torch::device(torch::kCUDA).dtype(torch::kByte));
+    tensor_ = ::torch::empty(size, ::torch::device(::torch::kCUDA).dtype(::torch::kByte));
   }
 }
 
@@ -34,25 +34,25 @@ TorchPersistentBuffer::AccessData(std::shared_ptr<OpContext> context) const {
   return tensor_.data_ptr();
 }
 
-TorchTensor::TorchTensor(torch::Tensor tensor) : tensor_(tensor) {}
+TorchTensor::TorchTensor(::torch::Tensor tensor) : tensor_(tensor) {}
 
 const MPIDataType TorchTensor::dtype() const {
   switch (tensor_.scalar_type()) {
-  case torch::kByte:
+  case ::torch::kByte:
     return common::HOROVOD_UINT8;
-  case torch::kChar:
+  case ::torch::kChar:
     return common::HOROVOD_INT8;
-  case torch::kShort:
+  case ::torch::kShort:
     return common::HOROVOD_INT16;
-  case torch::kInt:
+  case ::torch::kInt:
     return common::HOROVOD_INT32;
-  case torch::kLong:
+  case ::torch::kLong:
     return common::HOROVOD_INT64;
-  case torch::kHalf:
+  case ::torch::kHalf:
     return common::HOROVOD_FLOAT16;
-  case torch::kFloat:
+  case ::torch::kFloat:
     return common::HOROVOD_FLOAT32;
-  case torch::kDouble:
+  case ::torch::kDouble:
     return common::HOROVOD_FLOAT64;
   default:
     throw std::logic_error("Invalid tensor type.");
@@ -73,7 +73,7 @@ int64_t TorchTensor::size() const {
   return tensor_.type().elementSizeInBytes() * tensor_.numel();
 }
 
-TorchOpContext::TorchOpContext(int device, torch::Tensor output)
+TorchOpContext::TorchOpContext(int device, ::torch::Tensor output)
     : device_(device), output_(output) {}
 
 Status

--- a/horovod/torch/adapter_v2.cc
+++ b/horovod/torch/adapter_v2.cc
@@ -23,9 +23,9 @@ TorchPersistentBuffer::TorchPersistentBuffer(int device, int64_t size)
     : device_(device) {
   with_device device_context(device_);
   if (device_ == CPU_DEVICE_ID) {
-    tensor_ = at::empty({size}, at::device(at::kCPU).dtype(at::kByte));
+    tensor_ = torch::empty(size, torch::device(torch::kCPU).dtype(torch::kByte));
   } else {
-    tensor_ = at::empty({size}, at::device(at::kCUDA).dtype(at::kByte));
+    tensor_ = torch::empty(size, torch::device(torch::kCUDA).dtype(torch::kByte));
   }
 }
 
@@ -34,25 +34,25 @@ TorchPersistentBuffer::AccessData(std::shared_ptr<OpContext> context) const {
   return tensor_.data_ptr();
 }
 
-TorchTensor::TorchTensor(at::Tensor tensor) : tensor_(tensor) {}
+TorchTensor::TorchTensor(torch::Tensor tensor) : tensor_(tensor) {}
 
 const MPIDataType TorchTensor::dtype() const {
   switch (tensor_.scalar_type()) {
-  case at::ScalarType::Byte:
+  case torch::kByte:
     return common::HOROVOD_UINT8;
-  case at::ScalarType::Char:
+  case torch::kChar:
     return common::HOROVOD_INT8;
-  case at::ScalarType::Short:
+  case torch::kShort:
     return common::HOROVOD_INT16;
-  case at::ScalarType::Int:
+  case torch::kInt:
     return common::HOROVOD_INT32;
-  case at::ScalarType::Long:
+  case torch::kLong:
     return common::HOROVOD_INT64;
-  case at::ScalarType::Half:
+  case torch::kHalf:
     return common::HOROVOD_FLOAT16;
-  case at::ScalarType::Float:
+  case torch::kFloat:
     return common::HOROVOD_FLOAT32;
-  case at::ScalarType::Double:
+  case torch::kDouble:
     return common::HOROVOD_FLOAT64;
   default:
     throw std::logic_error("Invalid tensor type.");
@@ -73,7 +73,7 @@ int64_t TorchTensor::size() const {
   return tensor_.type().elementSizeInBytes() * tensor_.numel();
 }
 
-TorchOpContext::TorchOpContext(int device, at::Tensor output)
+TorchOpContext::TorchOpContext(int device, torch::Tensor output)
     : device_(device), output_(output) {}
 
 Status

--- a/horovod/torch/adapter_v2.h
+++ b/horovod/torch/adapter_v2.h
@@ -16,7 +16,7 @@
 #ifndef HOROVOD_TORCH_ADAPTER_V2_H
 #define HOROVOD_TORCH_ADAPTER_V2_H
 
-#include <torch/extension.h>
+#include <torch/torch.h>
 
 #include "../common/common.h"
 
@@ -33,24 +33,24 @@ public:
 
 private:
   int device_ = CPU_DEVICE_ID;
-  at::Tensor tensor_;
+  torch::Tensor tensor_;
 };
 
 class TorchTensor : public Tensor {
 public:
-  TorchTensor(at::Tensor tensor);
+  TorchTensor(torch::Tensor tensor);
   virtual const MPIDataType dtype() const override;
   virtual const TensorShape shape() const override;
   virtual const void* data() const override;
   virtual int64_t size() const override;
 
 protected:
-  at::Tensor tensor_;
+  torch::Tensor tensor_;
 };
 
 class TorchOpContext : public OpContext {
 public:
-  TorchOpContext(int device, at::Tensor output);
+  TorchOpContext(int device, torch::Tensor output);
   virtual Status
   AllocatePersistent(int64_t size,
                      std::shared_ptr<PersistentBuffer>* tensor) override;
@@ -60,7 +60,7 @@ public:
 
 private:
   int device_ = CPU_DEVICE_ID;
-  at::Tensor output_;
+  torch::Tensor output_;
 };
 
 void ThrowIfError(Status status);

--- a/horovod/torch/adapter_v2.h
+++ b/horovod/torch/adapter_v2.h
@@ -16,6 +16,7 @@
 #ifndef HOROVOD_TORCH_ADAPTER_V2_H
 #define HOROVOD_TORCH_ADAPTER_V2_H
 
+#include <torch/extension.h>
 #include <torch/torch.h>
 
 #include "../common/common.h"
@@ -33,24 +34,24 @@ public:
 
 private:
   int device_ = CPU_DEVICE_ID;
-  torch::Tensor tensor_;
+  ::torch::Tensor tensor_;
 };
 
 class TorchTensor : public Tensor {
 public:
-  TorchTensor(torch::Tensor tensor);
+  TorchTensor(::torch::Tensor tensor);
   virtual const MPIDataType dtype() const override;
   virtual const TensorShape shape() const override;
   virtual const void* data() const override;
   virtual int64_t size() const override;
 
 protected:
-  torch::Tensor tensor_;
+  ::torch::Tensor tensor_;
 };
 
 class TorchOpContext : public OpContext {
 public:
-  TorchOpContext(int device, torch::Tensor output);
+  TorchOpContext(int device, ::torch::Tensor output);
   virtual Status
   AllocatePersistent(int64_t size,
                      std::shared_ptr<PersistentBuffer>* tensor) override;
@@ -60,7 +61,7 @@ public:
 
 private:
   int device_ = CPU_DEVICE_ID;
-  torch::Tensor output_;
+  ::torch::Tensor output_;
 };
 
 void ThrowIfError(Status status);

--- a/horovod/torch/mpi_ops_v2.cc
+++ b/horovod/torch/mpi_ops_v2.cc
@@ -39,7 +39,7 @@ std::string GetOpName(const std::string& prefix, const std::string& name,
   return prefix + ".noname." + std::to_string(handle);
 }
 
-int GetDeviceID(const at::Tensor& tensor) {
+int GetDeviceID(const torch::Tensor& tensor) {
   if (tensor.device().is_cuda()) {
     return tensor.device().index();
   }
@@ -48,7 +48,7 @@ int GetDeviceID(const at::Tensor& tensor) {
 
 } // namespace
 
-int DoAllreduce(at::Tensor tensor, at::Tensor output, int average,
+int DoAllreduce(torch::Tensor tensor, torch::Tensor output, int average,
                 const std::string& name) {
   ThrowIfError(common::CheckInitialized());
 
@@ -74,14 +74,14 @@ int DoAllreduce(at::Tensor tensor, at::Tensor output, int average,
   return handle;
 }
 
-int DoAllreduceCudaOnCPU(at::Tensor tensor, at::Tensor output, int average,
+int DoAllreduceCudaOnCPU(torch::Tensor tensor, torch::Tensor output, int average,
                          const std::string& name) {
   ThrowIfError(common::CheckInitialized());
 
   // Make async copy of input tensor to CPU tensor and record completion event.
   auto device = GetDeviceID(tensor);
   auto cpu_buffer =
-      tensor.to(at::Device(at::DeviceType::CPU), /*non_blocking=*/true);
+      tensor.to(torch::Device(torch::kCPU), /*non_blocking=*/true);
   auto hvd_cpu_buffer = std::make_shared<TorchTensor>(cpu_buffer);
   auto ready_event = RecordReadyEvent(device);
 
@@ -108,7 +108,7 @@ int DoAllreduceCudaOnCPU(at::Tensor tensor, at::Tensor output, int average,
   return handle;
 }
 
-int DoAllgather(at::Tensor tensor, at::Tensor output, const std::string& name) {
+int DoAllgather(torch::Tensor tensor, torch::Tensor output, const std::string& name) {
   ThrowIfError(common::CheckInitialized());
 
   auto device = GetDeviceID(tensor);
@@ -128,18 +128,18 @@ int DoAllgather(at::Tensor tensor, at::Tensor output, const std::string& name) {
   return handle;
 }
 
-int DoAllgatherCudaOnCPU(at::Tensor tensor, at::Tensor output,
+int DoAllgatherCudaOnCPU(torch::Tensor tensor, torch::Tensor output,
                          const std::string& name) {
   ThrowIfError(common::CheckInitialized());
 
   // Make async copy of input tensor to CPU tensor and record completion event.
   auto device = GetDeviceID(tensor);
   auto cpu_tensor =
-      tensor.to(at::Device(at::DeviceType::CPU), /*non_blocking=*/true);
+      tensor.to(torch::Device(torch::kCPU), /*non_blocking=*/true);
   auto hvd_cpu_tensor = std::make_shared<TorchTensor>(cpu_tensor);
   auto ready_event = RecordReadyEvent(device);
 
-  auto cpu_output = at::empty_like(cpu_tensor);
+  auto cpu_output = torch::empty_like(cpu_tensor);
   auto hvd_cpu_output = std::make_shared<TorchTensor>(cpu_output);
   auto hvd_context =
       std::make_shared<TorchOpContext>(CPU_DEVICE_ID, cpu_output);
@@ -162,7 +162,7 @@ int DoAllgatherCudaOnCPU(at::Tensor tensor, at::Tensor output,
   return handle;
 }
 
-int DoBroadcast(at::Tensor tensor, at::Tensor output, int root_rank,
+int DoBroadcast(torch::Tensor tensor, torch::Tensor output, int root_rank,
                 const std::string& name) {
   ThrowIfError(common::CheckInitialized());
 
@@ -192,14 +192,14 @@ int DoBroadcast(at::Tensor tensor, at::Tensor output, int root_rank,
   return handle;
 }
 
-int DoBroadcastCudaOnCPU(at::Tensor tensor, at::Tensor output, int root_rank,
+int DoBroadcastCudaOnCPU(torch::Tensor tensor, torch::Tensor output, int root_rank,
                          const std::string& name) {
   ThrowIfError(common::CheckInitialized());
 
   // Make async copy of input tensor to CPU tensor and record completion event.
   auto device = GetDeviceID(tensor);
   auto cpu_buffer =
-      tensor.to(at::Device(at::DeviceType::CPU), /*non_blocking=*/true);
+      tensor.to(torch::Device(torch::kCPU), /*non_blocking=*/true);
   auto hvd_cpu_buffer = std::make_shared<TorchTensor>(cpu_buffer);
   auto ready_event = RecordReadyEvent(device);
 

--- a/horovod/torch/mpi_ops_v2.cc
+++ b/horovod/torch/mpi_ops_v2.cc
@@ -17,6 +17,7 @@
 #include <memory>
 #include <thread>
 #include <torch/extension.h>
+#include <torch/torch.h>
 
 #include "../common/operations.h"
 #include "adapter_v2.h"
@@ -39,7 +40,7 @@ std::string GetOpName(const std::string& prefix, const std::string& name,
   return prefix + ".noname." + std::to_string(handle);
 }
 
-int GetDeviceID(const torch::Tensor& tensor) {
+int GetDeviceID(const ::torch::Tensor& tensor) {
   if (tensor.device().is_cuda()) {
     return tensor.device().index();
   }
@@ -48,7 +49,7 @@ int GetDeviceID(const torch::Tensor& tensor) {
 
 } // namespace
 
-int DoAllreduce(torch::Tensor tensor, torch::Tensor output, int average,
+int DoAllreduce(::torch::Tensor tensor, ::torch::Tensor output, int average,
                 const std::string& name) {
   ThrowIfError(common::CheckInitialized());
 
@@ -74,14 +75,14 @@ int DoAllreduce(torch::Tensor tensor, torch::Tensor output, int average,
   return handle;
 }
 
-int DoAllreduceCudaOnCPU(torch::Tensor tensor, torch::Tensor output, int average,
+int DoAllreduceCudaOnCPU(::torch::Tensor tensor, ::torch::Tensor output, int average,
                          const std::string& name) {
   ThrowIfError(common::CheckInitialized());
 
   // Make async copy of input tensor to CPU tensor and record completion event.
   auto device = GetDeviceID(tensor);
   auto cpu_buffer =
-      tensor.to(torch::Device(torch::kCPU), /*non_blocking=*/true);
+      tensor.to(::torch::Device(::torch::kCPU), /*non_blocking=*/true);
   auto hvd_cpu_buffer = std::make_shared<TorchTensor>(cpu_buffer);
   auto ready_event = RecordReadyEvent(device);
 
@@ -108,7 +109,7 @@ int DoAllreduceCudaOnCPU(torch::Tensor tensor, torch::Tensor output, int average
   return handle;
 }
 
-int DoAllgather(torch::Tensor tensor, torch::Tensor output, const std::string& name) {
+int DoAllgather(::torch::Tensor tensor, ::torch::Tensor output, const std::string& name) {
   ThrowIfError(common::CheckInitialized());
 
   auto device = GetDeviceID(tensor);
@@ -128,18 +129,18 @@ int DoAllgather(torch::Tensor tensor, torch::Tensor output, const std::string& n
   return handle;
 }
 
-int DoAllgatherCudaOnCPU(torch::Tensor tensor, torch::Tensor output,
+int DoAllgatherCudaOnCPU(::torch::Tensor tensor, ::torch::Tensor output,
                          const std::string& name) {
   ThrowIfError(common::CheckInitialized());
 
   // Make async copy of input tensor to CPU tensor and record completion event.
   auto device = GetDeviceID(tensor);
   auto cpu_tensor =
-      tensor.to(torch::Device(torch::kCPU), /*non_blocking=*/true);
+      tensor.to(::torch::Device(::torch::kCPU), /*non_blocking=*/true);
   auto hvd_cpu_tensor = std::make_shared<TorchTensor>(cpu_tensor);
   auto ready_event = RecordReadyEvent(device);
 
-  auto cpu_output = torch::empty_like(cpu_tensor);
+  auto cpu_output = ::torch::empty_like(cpu_tensor);
   auto hvd_cpu_output = std::make_shared<TorchTensor>(cpu_output);
   auto hvd_context =
       std::make_shared<TorchOpContext>(CPU_DEVICE_ID, cpu_output);
@@ -162,7 +163,7 @@ int DoAllgatherCudaOnCPU(torch::Tensor tensor, torch::Tensor output,
   return handle;
 }
 
-int DoBroadcast(torch::Tensor tensor, torch::Tensor output, int root_rank,
+int DoBroadcast(::torch::Tensor tensor, ::torch::Tensor output, int root_rank,
                 const std::string& name) {
   ThrowIfError(common::CheckInitialized());
 
@@ -192,14 +193,14 @@ int DoBroadcast(torch::Tensor tensor, torch::Tensor output, int root_rank,
   return handle;
 }
 
-int DoBroadcastCudaOnCPU(torch::Tensor tensor, torch::Tensor output, int root_rank,
+int DoBroadcastCudaOnCPU(::torch::Tensor tensor, ::torch::Tensor output, int root_rank,
                          const std::string& name) {
   ThrowIfError(common::CheckInitialized());
 
   // Make async copy of input tensor to CPU tensor and record completion event.
   auto device = GetDeviceID(tensor);
   auto cpu_buffer =
-      tensor.to(torch::Device(torch::kCPU), /*non_blocking=*/true);
+      tensor.to(::torch::Device(::torch::kCPU), /*non_blocking=*/true);
   auto hvd_cpu_buffer = std::make_shared<TorchTensor>(cpu_buffer);
   auto ready_event = RecordReadyEvent(device);
 


### PR DESCRIPTION
ATen is still undergoing major churn and many things are moving from the `at::` namespace to the `c10::` namespace. Both namespaces are exported into the `torch::` namespace so you can save yourself some trouble by using `torch::` everywhere and never `at::`.