### PR TITLE
 Added force allreduce of all gradients in step()

### DIFF
--- a/horovod/torch/__init__.py
+++ b/horovod/torch/__init__.py
@@ -57,6 +57,11 @@ class _DistributedOptimizer(torch.optim.Optimizer):
 
         self._parameter_names = {v: k for k, v
                                  in sorted(named_parameters)}
+
+        if len(self._parameter_names) == 0:
+            self._parameter_names = {v: str(i) for param_group in self.param_groups
+                                     for i, v in enumerate(param_group['params'])}
+
         self._handles = {}
         self._grad_accs = []
         self._requires_update = set()

--- a/horovod/torch/__init__.py
+++ b/horovod/torch/__init__.py
@@ -55,11 +55,11 @@ class _DistributedOptimizer(torch.optim.Optimizer):
                              'tuples (name, parameter), usually produced by '
                              'model.named_parameters().')
 
-        self._parameter_names = {v: k for k, v
-                                 in sorted(named_parameters)}
-
-        if len(self._parameter_names) == 0:
-            self._parameter_names = {v: str(i) for param_group in self.param_groups
+        if len(named_parameters) > 0:
+            self._parameter_names = {v: k for k, v
+                                     in sorted(named_parameters)}
+        else:
+            self._parameter_names = {v: 'allreduce.noname.%s' % i for param_group in self.param_groups
                                      for i, v in enumerate(param_group['params'])}
 
         self._handles = {}

--- a/horovod/torch/__init__.py
+++ b/horovod/torch/__init__.py
@@ -204,7 +204,7 @@ def broadcast_optimizer_state(optimizer, root_rank):
         for group in optimizer.param_groups:
             for p in group['params']:
                 p.grad = p.data.new(p.size()).zero_()
-        if type(optimizer).__module__.startswith('horovod'):
+        if optimizer.__module__ == DistributedOptimizer.__module__:
             super(optimizer.__class__, optimizer).step()
         else:
             optimizer.step()

--- a/horovod/torch/__init__.py
+++ b/horovod/torch/__init__.py
@@ -205,6 +205,11 @@ def broadcast_optimizer_state(optimizer, root_rank):
         for group in optimizer.param_groups:
             for p in group['params']:
                 p.grad = p.data.new(p.size()).zero_()
+        # This function accepts a torch.optim.Optimizer or a DistributedOptimizer
+        # wrapped around a torch optimizer. Calling step() with a DistributedOptimizer
+        # forces allreduce on all model parameters, which will result in deadlock
+        # unless every rank calls step(). Therefore, to finish state initialization
+        # only call optimizer.step() with a torch.optim.Optimizer.
         if optimizer.__module__ == DistributedOptimizer.__module__:
             super(optimizer.__class__, optimizer).step()
         else:

--- a/horovod/torch/__init__.py
+++ b/horovod/torch/__init__.py
@@ -99,7 +99,6 @@ class _DistributedOptimizer(torch.optim.Optimizer):
     def synchronize(self):
         missing_p = self._requires_update - set(self._handles.keys())
         for p in missing_p:
-            # p.grad = torch.zeros(p.shape, dtype=p.dtype, device=p.device)
             self._allreduce_grad(p)
 
         for p, value in self._handles.items():

--- a/horovod/torch/__init__.py
+++ b/horovod/torch/__init__.py
@@ -204,7 +204,10 @@ def broadcast_optimizer_state(optimizer, root_rank):
         for group in optimizer.param_groups:
             for p in group['params']:
                 p.grad = p.data.new(p.size()).zero_()
-        super(optimizer.__class__, optimizer).step()
+        if type(optimizer).__module__.startswith('horovod'):
+            super(optimizer.__class__, optimizer).step()
+        else:
+            optimizer.step()
         state_dict = optimizer.state_dict()
 
     # If the state_dict is still empty after initialization, then

--- a/horovod/torch/__init__.py
+++ b/horovod/torch/__init__.py
@@ -204,7 +204,7 @@ def broadcast_optimizer_state(optimizer, root_rank):
         for group in optimizer.param_groups:
             for p in group['params']:
                 p.grad = p.data.new(p.size()).zero_()
-        optimizer.step()
+        super(optimizer.__class__, optimizer).step()
         state_dict = optimizer.state_dict()
 
     # If the state_dict is still empty after initialization, then

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -962,7 +962,7 @@ class TorchTests(unittest.TestCase):
                 self.assertLess(err, 0.00000001)
 
     def test_force_allreduce(self):
-        """Test that allreduce is forced on all gradients during opt.step() even if gradient hook isn not called during loss.backward()."""
+        """Test that allreduce is forced on all gradients during opt.step()."""
         hvd.init()
         rank = hvd.rank()
         size = hvd.size()

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -960,3 +960,72 @@ class TorchTests(unittest.TestCase):
                 expected = np.ones(tensor_size)
                 err = np.linalg.norm(expected - tensor_decompressed.data.numpy())
                 self.assertLess(err, 0.00000001)
+
+    def test_force_allreduce(self):
+        """Test that allreduce is forced on all gradients during opt.step() even if gradient hook isn not called during loss.backward()."""
+        hvd.init()
+        rank = hvd.rank()
+        size = hvd.size()
+
+        # This test does not apply if there is only one worker.
+        if size == 1:
+            return
+
+        N, D_in, H, D_out = 64, 100, 10, 10
+        x = torch.randn(N, D_in).requires_grad_()
+        y = torch.randn(N, D_out).requires_grad_()
+
+        def new_optimizer(cls, opt_params, model):
+            p = {
+                k: v for k, v in opt_params.items()
+                if k in inspect.getargspec(cls.__init__).args
+            }
+            return cls(model.parameters(), **p)
+
+        class Net(torch.nn.Module):
+            def __init__(self):
+                super(Net, self).__init__()
+                self.fc1 = torch.nn.Linear(D_in, H)
+                self.fc2 = torch.nn.Linear(H, D_out)
+                self.fc3 = torch.nn.Linear(D_out, D_out)
+
+            def forward(self, x_):
+                x_ = F.relu(self.fc1(x_))
+                x1_ = self.fc2(x_)
+                x2_ = self.fc3(F.relu(x1_))
+                return x1_, x2_
+
+        def create_model(opt_class, opt_params):
+            model = Net()
+            hvd.broadcast_parameters(model.state_dict(), root_rank=0)
+            opt = new_optimizer(opt_class, opt_params, model)
+            opt = hvd.DistributedOptimizer(
+                opt, named_parameters=model.named_parameters())
+            return model, opt
+
+        # L-BFGS is currently unsupported, as are sparse tensors, which are
+        # required by SparseAdam optimizer
+        optimizers = [
+            (subclass.__name__, subclass)
+            for subclass in torch.optim.Optimizer.__subclasses__()
+            if subclass.__module__.startswith('torch.optim') and
+               subclass != torch.optim.LBFGS and
+               subclass != torch.optim.SparseAdam
+        ]
+        optimizers.sort()
+
+        opt_params_list = [
+            dict(lr=0.2, momentum=0.9, weight_decay=0.1, centered=True),
+            dict(lr=0.2)
+        ]
+
+        for (opt_name, opt_class), opt_params in itertools.product(optimizers, opt_params_list):
+            model, optimizer = create_model(opt_class, opt_params)
+            y_pred1, y_pred2 = model(x)
+            if rank == 0:
+                loss = F.mse_loss(y_pred1, y, size_average=False)
+            else:
+                loss = F.mse_loss(y_pred2, y, size_average=False)
+            optimizer.zero_grad()
+            loss.backward()
+            optimizer.step()


### PR DESCRIPTION
Addresses Issue #564
1) Added a set, ```self._requires_update```, to ensure that all gradients are passed to allreduce even if a gradient is not calculated during ```loss.backward()```. If a gradient is not calculated, assume the gradient should be set to 0.

2) Added a function ```_allreduce_grad(self, p)``` to avoid redundant code because this is called both when making hooks and when forcing allreduce on missing gradients.

3) Created arbitrary parameter names even if ```model.named_parameters()``` is not passed into ```DistributedOptimizer()```. This ensures that the gradients which were forced to allreduce on one replica know which gradients to communicate with on the other replicas. Otherwise replicas will have communication problems about which gradients to perform allreduce on.