### PR TITLE
Fix memory leak in pytorch_imagenet_resnet50.py example

### DIFF
--- a/examples/pytorch_imagenet_resnet50.py
+++ b/examples/pytorch_imagenet_resnet50.py
@@ -241,7 +241,7 @@ class Metric(object):
         self.n = torch.tensor(0.)
 
     def update(self, val):
-        self.sum += hvd.allreduce(val.cpu(), name=self.name)
+        self.sum += hvd.allreduce(val.detach().cpu(), name=self.name)
         self.n += 1
 
     @property


### PR DESCRIPTION
The current examples reduces the `loss` which, during training, carries with itself the computation graph. This results in a memory leak which in my case resulted in OOM errors.

[Detaching](https://pytorch.org/docs/stable/autograd.html#torch.Tensor.detach) the variable before reduction solved the memory leak for me.