### PR TITLE
Fix Python3.6 integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,18 +24,18 @@ before_install:
   - sleep 5
   - export CONTAINER=$(docker ps -q | head -n 1)
   - docker exec ${CONTAINER} /bin/sh -c "apt-get update -qq"
+  # install necessary network tools
+  - docker exec ${CONTAINER} /bin/sh -c "apt-get install -y wget openssh-client git"
   # install Python, if it's Python 3 - add symlink for `python`
   - |
     if [[ ${TRAVIS_PYTHON_VERSION} == 3* ]]; then
-      docker exec ${CONTAINER} /bin/sh -c "apt-get install -y python${TRAVIS_PYTHON_VERSION} python${TRAVIS_PYTHON_VERSION}-dev python3-pip python3-requests"
-      docker exec ${CONTAINER} /bin/sh -c "pip3 install -U --force pip setuptools"
+      docker exec ${CONTAINER} /bin/sh -c "apt-get install -y python${TRAVIS_PYTHON_VERSION} python${TRAVIS_PYTHON_VERSION}-dev"
       docker exec ${CONTAINER} /bin/sh -c "ln -s /usr/bin/python3 /usr/bin/python"
     else
-      docker exec ${CONTAINER} /bin/sh -c "apt-get install -y python${TRAVIS_PYTHON_VERSION} python${TRAVIS_PYTHON_VERSION}-dev python-pip python-requests"
-      docker exec ${CONTAINER} /bin/sh -c "pip install -U --force pip setuptools"
+      docker exec ${CONTAINER} /bin/sh -c "apt-get install -y python${TRAVIS_PYTHON_VERSION} python${TRAVIS_PYTHON_VERSION}-dev"
     fi
-  # install necessary network tools
-  - docker exec ${CONTAINER} /bin/sh -c "apt-get install -y wget openssh-client git"
+  - docker exec ${CONTAINER} /bin/sh -c "wget https://bootstrap.pypa.io/get-pip.py && python get-pip.py && rm get-pip.py"
+  - docker exec ${CONTAINER} /bin/sh -c "pip install -U --force pip setuptools requests"
 
 env:
   matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,9 +26,10 @@ before_install:
   - docker exec ${CONTAINER} /bin/sh -c "apt-get update -qq"
   # install necessary network tools
   - docker exec ${CONTAINER} /bin/sh -c "apt-get install -y wget openssh-client git build-essential"
-  # install Python, if it's Python 3 - add symlink for `python`
+  # install Python and add a proper symlink
   - |
-    if [[ ${TRAVIS_PYTHON_VERSION} == 3* ]]; then
+    if [[ ${TRAVIS_PYTHON_VERSION} == "3.6" ]]; then
+      # Python 3.6 requires special handling in Debian `sid` since the default is Python 3.7.
       docker exec ${CONTAINER} /bin/sh -c "apt-get install -y python${TRAVIS_PYTHON_VERSION} python${TRAVIS_PYTHON_VERSION}-dev python3-distutils"
     else
       docker exec ${CONTAINER} /bin/sh -c "apt-get install -y python${TRAVIS_PYTHON_VERSION} python${TRAVIS_PYTHON_VERSION}-dev"

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ before_install:
   # install Python, if it's Python 3 - add symlink for `python`
   - |
     if [[ ${TRAVIS_PYTHON_VERSION} == 3* ]]; then
-      docker exec ${CONTAINER} /bin/sh -c "apt-get install -y python${TRAVIS_PYTHON_VERSION} python${TRAVIS_PYTHON_VERSION}-dev"
+      docker exec ${CONTAINER} /bin/sh -c "apt-get install -y python${TRAVIS_PYTHON_VERSION} python${TRAVIS_PYTHON_VERSION}-dev python3-distutils"
     else
       docker exec ${CONTAINER} /bin/sh -c "apt-get install -y python${TRAVIS_PYTHON_VERSION} python${TRAVIS_PYTHON_VERSION}-dev"
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,10 +30,10 @@ before_install:
   - |
     if [[ ${TRAVIS_PYTHON_VERSION} == 3* ]]; then
       docker exec ${CONTAINER} /bin/sh -c "apt-get install -y python${TRAVIS_PYTHON_VERSION} python${TRAVIS_PYTHON_VERSION}-dev"
-      docker exec ${CONTAINER} /bin/sh -c "ln -s /usr/bin/python3 /usr/bin/python"
     else
       docker exec ${CONTAINER} /bin/sh -c "apt-get install -y python${TRAVIS_PYTHON_VERSION} python${TRAVIS_PYTHON_VERSION}-dev"
     fi
+  - docker exec ${CONTAINER} /bin/sh -c "ln -s /usr/bin/python${TRAVIS_PYTHON_VERSION} /usr/bin/python"
   - docker exec ${CONTAINER} /bin/sh -c "wget https://bootstrap.pypa.io/get-pip.py && python get-pip.py && rm get-pip.py"
   - docker exec ${CONTAINER} /bin/sh -c "pip install -U --force pip setuptools requests"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ before_install:
   - export CONTAINER=$(docker ps -q | head -n 1)
   - docker exec ${CONTAINER} /bin/sh -c "apt-get update -qq"
   # install necessary network tools
-  - docker exec ${CONTAINER} /bin/sh -c "apt-get install -y wget openssh-client git"
+  - docker exec ${CONTAINER} /bin/sh -c "apt-get install -y wget openssh-client git build-essential"
   # install Python, if it's Python 3 - add symlink for `python`
   - |
     if [[ ${TRAVIS_PYTHON_VERSION} == 3* ]]; then


### PR DESCRIPTION
Debian `sid` started including Python 3.7, and so `python3` now have a different meaning.  Update the integration tests to resolve this issue.