### PR TITLE
Adds a logging framework

### DIFF
--- a/horovod/common/logging.cc
+++ b/horovod/common/logging.cc
@@ -1,5 +1,7 @@
 #include <chrono>
 #include <algorithm>
+#include <iostream>
+#include <iomanip>
 
 #include "logging.h"
 
@@ -10,6 +12,8 @@ LogMessage::LogMessage(const char* fname, int line, LogLevel severity)
     : fname_(fname), line_(line), severity_(severity) {}
 
 void LogMessage::GenerateLogMessage(bool log_time) {
+  bool use_cout = static_cast<int>(severity_) <= static_cast<int>(LogLevel::INFO);
+  std::ostream& os = use_cout ? std::cout : std::cerr;
   if (log_time) {
     auto now = std::chrono::system_clock::now();
     auto as_time_t = std::chrono::system_clock::to_time_t(now);
@@ -22,12 +26,12 @@ void LogMessage::GenerateLogMessage(bool log_time) {
     char time_buffer[time_buffer_size];
     strftime(time_buffer, time_buffer_size, "%Y-%m-%d %H:%M:%S",
              localtime(&as_time_t));
-
-    fprintf(stdout, "[%s.%06d: %c %s:%d] %s\n", time_buffer, micros_remainder,
-            LOG_LEVELS[static_cast<int>(severity_)], fname_, line_, str().c_str());  
+    os << "[" << time_buffer << "." << std::setw(6) << micros_remainder.count() 
+              << ": " << LOG_LEVELS[static_cast<int>(severity_)] << " " 
+              << fname_ << ":" << line_ << "] " << str() << std::endl;
   } else {
-    fprintf(stdout, "[%c %s:%d] %s\n", LOG_LEVELS[static_cast<int>(severity_)], 
-            fname_, line_, str().c_str());  
+    os << "[" << LOG_LEVELS[static_cast<int>(severity_)] << " " 
+              << fname_ << ":" << line_ << "] " << str() << std::endl;
   }
 }
 

--- a/horovod/common/logging.cc
+++ b/horovod/common/logging.cc
@@ -79,7 +79,7 @@ int MinLogLevelFromEnv() {
 bool LogTimeFromEnv() {
   const char* env_var_val = getenv("HOROVOD_LOG_TIME_DISABLE");
   if (env_var_val != nullptr &&
-      std::strtol(env_var_val, nullptr, 10) <= 0) {
+      std::strtol(env_var_val, nullptr, 10) > 0) {
     return false;
   } else {
     return true;

--- a/horovod/common/logging.cc
+++ b/horovod/common/logging.cc
@@ -87,7 +87,7 @@ int MinLogLevelFromEnv() {
 }
 
 bool LogTimeFromEnv() {
-  const char* env_var_val = getenv("HOROVOD_LOG_TIME_DISABLE");
+  const char* env_var_val = getenv("HOROVOD_LOG_HIDE_TIME");
   if (env_var_val != nullptr &&
       std::strtol(env_var_val, nullptr, 10) > 0) {
     return false;

--- a/horovod/common/logging.cc
+++ b/horovod/common/logging.cc
@@ -1,0 +1,73 @@
+#include <chrono>
+
+#include "logging.h"
+
+namespace horovod {
+namespace common {
+
+LogMessage::LogMessage(const char* fname, int line, int severity)
+    : fname_(fname), line_(line), severity_(severity) {}
+
+void LogMessage::GenerateLogMessage() {
+  auto now = std::chrono::system_clock::now();
+  auto as_time_t = std::chrono::system_clock::to_time_t(now);
+
+  auto duration = now.time_since_epoch();
+  auto seconds = std::chrono::duration_cast<std::chrono::seconds>(duration);
+  auto micros_remainder = std::chrono::duration_cast<std::chrono::microseconds>(duration - seconds);
+
+  const size_t time_buffer_size = 30;
+  char time_buffer[time_buffer_size];
+  strftime(time_buffer, time_buffer_size, "%Y-%m-%d %H:%M:%S",
+           localtime(&as_time_t));
+
+  fprintf(stdout, "[%s.%06d: %c %s:%d] %s\n", time_buffer, micros_remainder,
+          "TDIWEF"[severity_], fname_, line_, str().c_str());
+}
+
+LogMessage::~LogMessage() {
+  // Read the min log level once during the first call to logging.
+  static int min_log_level = MinLogLevelFromEnv();
+  if (severity_ >= min_log_level) GenerateLogMessage();
+}
+
+
+LogMessageFatal::LogMessageFatal(const char* file, int line)
+    : LogMessage(file, line, FATAL) {}
+LogMessageFatal::~LogMessageFatal() {
+  GenerateLogMessage();
+  abort();
+}
+
+void LogString(const char* fname, int line, int severity,
+               const std::string& message) {
+  LogMessage(fname, line, severity) << message;
+}
+
+int LogLevelStrToInt(const char* env_var_val) {
+  if (env_var_val == nullptr) {
+    return 0;
+  }
+  std::string min_log_level(env_var_val);
+  std::istringstream ss(min_log_level);
+  int level;
+  if (!(ss >> level)) {
+    // Invalid log level setting, set level to default (0)
+    level = 0;
+  }
+
+  return level;
+}
+
+int MinLogLevelFromEnv() {
+  const char* env_var_val = getenv("HOROVOD_LOG_LEVEL");
+  if (env_var_val == nullptr) {
+    // default to WARN
+    return 3;
+  }
+  return LogLevelStrToInt(env_var_val);
+}
+
+
+}
+}

--- a/horovod/common/logging.cc
+++ b/horovod/common/logging.cc
@@ -1,4 +1,5 @@
 #include <chrono>
+#include <algorithm>
 
 #include "logging.h"
 
@@ -54,24 +55,33 @@ void LogString(const char* fname, int line, int severity,
 
 int LogLevelStrToInt(const char* env_var_val) {
   if (env_var_val == nullptr) {
-    return 0;
+    // default to WARN
+    return WARNING;
   }
   std::string min_log_level(env_var_val);
-  std::istringstream ss(min_log_level);
-  int level;
-  if (!(ss >> level)) {
-    // Invalid log level setting, set level to default (0)
-    level = 0;
+  std::transform(min_log_level.begin(), min_log_level.end(), min_log_level.begin(), ::tolower);
+  if (min_log_level == "trace") {
+    return TRACE;
+  } else if (min_log_level == "debug") {
+    return DEBUG;
+  } else if (min_log_level == "info") {
+    return INFO;
+  } else if (min_log_level == "warning") {
+    return WARNING;
+  } else if (min_log_level == "error") {
+    return ERROR;
+  } else if (min_log_level == "fatal") {
+    return FATAL;
+  } else {
+    return WARNING;
   }
-
-  return level;
 }
 
 int MinLogLevelFromEnv() {
   const char* env_var_val = getenv("HOROVOD_LOG_LEVEL");
   if (env_var_val == nullptr) {
     // default to WARN
-    return 3;
+    return WARNING;
   }
   return LogLevelStrToInt(env_var_val);
 }

--- a/horovod/common/logging.h
+++ b/horovod/common/logging.h
@@ -20,7 +20,7 @@ class LogMessage : public std::basic_ostringstream<char> {
   ~LogMessage();
 
  protected:
-  void GenerateLogMessage();
+  void GenerateLogMessage(bool log_time);
 
  private:
   const char* fname_;
@@ -57,6 +57,7 @@ class LogMessageFatal : public LogMessage {
 #define LOG(...) GET_LOG(__VA_ARGS__, _LOG_RANK, _LOG)(__VA_ARGS__)
 
 int MinLogLevelFromEnv();
+bool LogTimeFromEnv();
 
 }
 }

--- a/horovod/common/logging.h
+++ b/horovod/common/logging.h
@@ -49,9 +49,12 @@ class LogMessageFatal : public LogMessage {
 #define _HVD_LOG_FATAL \
   LogMessageFatal(__FILE__, __LINE__)
 
-#define LOG(severity) _HVD_LOG_##severity
+#define _LOG(severity) _HVD_LOG_##severity
 
-#define LOG_RANK(severity, rank) _HVD_LOG_##severity << "[" << rank << "]: "
+#define _LOG_RANK(severity, rank) _HVD_LOG_##severity << "[" << rank << "]: "
+
+#define GET_LOG(_1, _2, NAME, ...) NAME
+#define LOG(...) GET_LOG(__VA_ARGS__, _LOG_RANK, _LOG)(__VA_ARGS__)
 
 int MinLogLevelFromEnv();
 

--- a/horovod/common/logging.h
+++ b/horovod/common/logging.h
@@ -1,0 +1,58 @@
+#include <limits>
+#include <sstream>
+
+namespace horovod {
+namespace common {
+const int DEBUG = 0;
+const int INFO = 1;
+const int WARNING = 2;
+const int ERROR = 3;
+const int FATAL = 4;
+const int NUM_SEVERITIES = 5;
+
+class LogMessage : public std::basic_ostringstream<char> {
+ public:
+  LogMessage(const char* fname, int line, int severity);
+  ~LogMessage();
+
+  // Returns the minimum log level for VLOG statements.
+  // E.g., if MinVLogLevel() is 2, then VLOG(2) statements will produce output,
+  // but VLOG(3) will not. Defaults to 0.
+  static int64 MinVLogLevel();
+
+ protected:
+  void GenerateLogMessage();
+
+ private:
+  const char* fname_;
+  int line_;
+  int severity_;
+};
+
+// LogMessageFatal ensures the process will exit in failure after
+// logging this message.
+class LogMessageFatal : public LogMessage {
+ public:
+  LogMessageFatal(const char* file, int line) TF_ATTRIBUTE_COLD;
+  TF_ATTRIBUTE_NORETURN ~LogMessageFatal();
+};
+
+#define _TF_LOG_INFO \
+  ::tensorflow::internal::LogMessage(__FILE__, __LINE__, ::tensorflow::INFO)
+#define _TF_LOG_WARNING \
+  ::tensorflow::internal::LogMessage(__FILE__, __LINE__, ::tensorflow::WARNING)
+#define _TF_LOG_ERROR \
+  ::tensorflow::internal::LogMessage(__FILE__, __LINE__, ::tensorflow::ERROR)
+#define _TF_LOG_FATAL \
+  ::tensorflow::internal::LogMessageFatal(__FILE__, __LINE__)
+
+#define LOG(severity) _TF_LOG_##severity
+
+#define _TF_LOG_QFATAL _TF_LOG_FATAL
+
+int64 MinLogLevelFromEnv();
+
+int64 MinVLogLevelFromEnv();
+
+}
+}

--- a/horovod/common/logging.h
+++ b/horovod/common/logging.h
@@ -1,24 +1,23 @@
-#include <limits>
 #include <sstream>
+#include <string>
 
 namespace horovod {
 namespace common {
-const int DEBUG = 0;
-const int INFO = 1;
-const int WARNING = 2;
-const int ERROR = 3;
-const int FATAL = 4;
-const int NUM_SEVERITIES = 5;
+
+const int TRACE = 0;
+const int DEBUG = 1;
+const int INFO = 2;
+const int WARNING = 3;
+const int ERROR = 4;
+const int FATAL = 5;
+
+void LogString(const char* fname, int line, int severity,
+               const std::string& message);
 
 class LogMessage : public std::basic_ostringstream<char> {
  public:
   LogMessage(const char* fname, int line, int severity);
   ~LogMessage();
-
-  // Returns the minimum log level for VLOG statements.
-  // E.g., if MinVLogLevel() is 2, then VLOG(2) statements will produce output,
-  // but VLOG(3) will not. Defaults to 0.
-  static int64 MinVLogLevel();
 
  protected:
   void GenerateLogMessage();
@@ -33,26 +32,28 @@ class LogMessage : public std::basic_ostringstream<char> {
 // logging this message.
 class LogMessageFatal : public LogMessage {
  public:
-  LogMessageFatal(const char* file, int line) TF_ATTRIBUTE_COLD;
-  TF_ATTRIBUTE_NORETURN ~LogMessageFatal();
+  LogMessageFatal(const char* file, int line);
+  ~LogMessageFatal();
 };
 
-#define _TF_LOG_INFO \
-  ::tensorflow::internal::LogMessage(__FILE__, __LINE__, ::tensorflow::INFO)
-#define _TF_LOG_WARNING \
-  ::tensorflow::internal::LogMessage(__FILE__, __LINE__, ::tensorflow::WARNING)
-#define _TF_LOG_ERROR \
-  ::tensorflow::internal::LogMessage(__FILE__, __LINE__, ::tensorflow::ERROR)
-#define _TF_LOG_FATAL \
-  ::tensorflow::internal::LogMessageFatal(__FILE__, __LINE__)
+#define _HVD_LOG_TRACE \
+  LogMessage(__FILE__, __LINE__, TRACE)
+#define _HVD_LOG_DEBUG \
+  LogMessage(__FILE__, __LINE__, DEBUG)
+#define _HVD_LOG_INFO \
+  LogMessage(__FILE__, __LINE__, INFO)
+#define _HVD_LOG_WARNING \
+  LogMessage(__FILE__, __LINE__, WARNING)
+#define _HVD_LOG_ERROR \
+  LogMessage(__FILE__, __LINE__, ERROR)
+#define _HVD_LOG_FATAL \
+  LogMessageFatal(__FILE__, __LINE__)
 
-#define LOG(severity) _TF_LOG_##severity
+#define LOG(severity) _HVD_LOG_##severity
 
-#define _TF_LOG_QFATAL _TF_LOG_FATAL
+#define LOG_RANK(severity, rank) _HVD_LOG_##severity << "[" << rank << "]: "
 
-int64 MinLogLevelFromEnv();
-
-int64 MinVLogLevelFromEnv();
+int MinLogLevelFromEnv();
 
 }
 }

--- a/horovod/common/logging.h
+++ b/horovod/common/logging.h
@@ -4,19 +4,15 @@
 namespace horovod {
 namespace common {
 
-const int TRACE = 0;
-const int DEBUG = 1;
-const int INFO = 2;
-const int WARNING = 3;
-const int ERROR = 4;
-const int FATAL = 5;
+enum class LogLevel {
+  TRACE, DEBUG, INFO, WARNING, ERROR, FATAL
+};
 
-void LogString(const char* fname, int line, int severity,
-               const std::string& message);
+#define LOG_LEVELS "TDIWEF"
 
 class LogMessage : public std::basic_ostringstream<char> {
  public:
-  LogMessage(const char* fname, int line, int severity);
+  LogMessage(const char* fname, int line, LogLevel severity);
   ~LogMessage();
 
  protected:
@@ -25,7 +21,7 @@ class LogMessage : public std::basic_ostringstream<char> {
  private:
   const char* fname_;
   int line_;
-  int severity_;
+  LogLevel severity_;
 };
 
 // LogMessageFatal ensures the process will exit in failure after
@@ -37,15 +33,15 @@ class LogMessageFatal : public LogMessage {
 };
 
 #define _HVD_LOG_TRACE \
-  LogMessage(__FILE__, __LINE__, TRACE)
+  LogMessage(__FILE__, __LINE__, LogLevel::TRACE)
 #define _HVD_LOG_DEBUG \
-  LogMessage(__FILE__, __LINE__, DEBUG)
+  LogMessage(__FILE__, __LINE__, LogLevel::DEBUG)
 #define _HVD_LOG_INFO \
-  LogMessage(__FILE__, __LINE__, INFO)
+  LogMessage(__FILE__, __LINE__, LogLevel::INFO)
 #define _HVD_LOG_WARNING \
-  LogMessage(__FILE__, __LINE__, WARNING)
+  LogMessage(__FILE__, __LINE__, LogLevel::WARNING)
 #define _HVD_LOG_ERROR \
-  LogMessage(__FILE__, __LINE__, ERROR)
+  LogMessage(__FILE__, __LINE__, LogLevel::ERROR)
 #define _HVD_LOG_FATAL \
   LogMessageFatal(__FILE__, __LINE__)
 
@@ -56,7 +52,7 @@ class LogMessageFatal : public LogMessage {
 #define GET_LOG(_1, _2, NAME, ...) NAME
 #define LOG(...) GET_LOG(__VA_ARGS__, _LOG_RANK, _LOG)(__VA_ARGS__)
 
-int MinLogLevelFromEnv();
+LogLevel MinLogLevelFromEnv();
 bool LogTimeFromEnv();
 
 }

--- a/horovod/common/mpi_message.cc
+++ b/horovod/common/mpi_message.cc
@@ -251,6 +251,12 @@ const std::vector<std::string>& MPIResponse::tensor_names() const {
   return tensor_names_;
 }
 
+const std::string MPIResponse::tensor_names_string() const {
+  std::string result;
+  for (auto const& s : tensor_names_) { result += s; }
+  return result;
+}
+
 void MPIResponse::set_tensor_names(const std::vector<std::string>& value) {
   tensor_names_ = value;
 }

--- a/horovod/common/mpi_message.cc
+++ b/horovod/common/mpi_message.cc
@@ -253,7 +253,15 @@ const std::vector<std::string>& MPIResponse::tensor_names() const {
 
 const std::string MPIResponse::tensor_names_string() const {
   std::string result;
-  for (auto const& s : tensor_names_) { result += s; }
+  bool is_first_name = true;
+  for (auto const& s : tensor_names_) {
+    if (!is_first_name) {
+      result += ",";
+    } else {
+      is_first_name = false;
+    }
+    result += s;
+  }
   return result;
 }
 

--- a/horovod/common/mpi_message.cc
+++ b/horovod/common/mpi_message.cc
@@ -256,7 +256,7 @@ const std::string MPIResponse::tensor_names_string() const {
   bool is_first_name = true;
   for (auto const& s : tensor_names_) {
     if (!is_first_name) {
-      result += ",";
+      result += ", ";
     } else {
       is_first_name = false;
     }

--- a/horovod/common/mpi_message.h
+++ b/horovod/common/mpi_message.h
@@ -124,6 +124,7 @@ public:
 
   // Empty if the type is DONE or SHUTDOWN.
   const std::vector<std::string>& tensor_names() const;
+  const std::string tensor_names_string() const;
   void set_tensor_names(const std::vector<std::string>& value);
   void add_tensor_names(const std::string& value);
 

--- a/horovod/common/operations.cc
+++ b/horovod/common/operations.cc
@@ -1948,9 +1948,11 @@ bool RunLoopOnce(HorovodGlobalState& state, bool is_coordinator) {
       message_queue.push(message);
     }
   }
-
-  // if (!message_queue.empty()) LOG(DEBUG, state.rank) << "Sent " << message_queue.size() << " messages";
-
+  
+  if (!message_queue.empty()) {
+    LOG(DEBUG, state.rank) << "Sent " << message_queue.size() << " messages";
+  }
+  
   // Flag indicating that the background thread should shut down.
   bool should_shut_down = state.shut_down;
 

--- a/horovod/common/operations.cc
+++ b/horovod/common/operations.cc
@@ -44,6 +44,7 @@
 #include "mpi_message.h"
 #include "operations.h"
 #include "timeline.h"
+#include "logging.h"
 
 /*
  * Allreduce, Allgather and Broadcast Ops.
@@ -1811,6 +1812,8 @@ void BackgroundThreadLoop(HorovodGlobalState& state) {
   // Signal that initialization is completed.
   state.initialization_done = true;
 
+  LOG(INFO) << "HVD Initialized";
+  
   // Iterate until shutdown.
   while (RunLoopOnce(state, is_coordinator))
     ;

--- a/horovod/common/operations.cc
+++ b/horovod/common/operations.cc
@@ -2080,12 +2080,14 @@ bool RunLoopOnce(HorovodGlobalState& state, bool is_coordinator) {
       }
     }
 
-    std::string tensors_ready;
-    for (auto r : response_list.responses()) {
-      tensors_ready += r.tensor_names_string() + "; " ;
+    if (!response_list.responses().empty()) {
+      std::string tensors_ready;
+      for (auto r : response_list.responses()) {
+        tensors_ready += r.tensor_names_string() + "; " ;
+      }
+      LOG(TRACE) << "Sending ready responses as " << tensors_ready;  
     }
-    LOG(TRACE) << "Sending ready responses as " << tensors_ready;
-
+    
     // Notify all nodes which tensors we'd like to reduce at this step.
     std::string encoded_response;
     MPIResponseList::SerializeToString(response_list, encoded_response);

--- a/horovod/common/operations.cc
+++ b/horovod/common/operations.cc
@@ -1767,7 +1767,7 @@ void BackgroundThreadLoop(HorovodGlobalState& state) {
                  (size != local_size);
     state.param_manager.SetHierarchicalAllgather(value, true);
   }
-
+  
   // Set flag for hierarchical allreduce. Ignore if Horovod is running on a
   // single node.
   auto horovod_hierarchical_allreduce = std::getenv(HOROVOD_HIERARCHICAL_ALLREDUCE);
@@ -1777,7 +1777,6 @@ void BackgroundThreadLoop(HorovodGlobalState& state) {
                  (size != local_size);
     state.param_manager.SetHierarchicalAllreduce(value, true);
   }
-  if (state.hierarchical_allreduce) LOG(INFO) << "Using Hierarchical Allreduce";
 
 #if HOROVOD_GPU_ALLREDUCE != 'N' && HOROVOD_GPU_ALLREDUCE != 'D'
   // Hierarchical allreduce is not supported without NCCL or DDL
@@ -1803,7 +1802,6 @@ void BackgroundThreadLoop(HorovodGlobalState& state) {
                                    horovod_autotune_log != nullptr ? std::string(horovod_autotune_log) : "");
     state.param_manager.SetAutoTuning(true);
   }
-  if (is_coordinator) LOG(INFO) << "Using fusion threshold of " << state.tensor_fusion_threshold;
 
   // Initialize the tensor count table. No tensors are available yet.
   if (is_coordinator) {

--- a/horovod/common/operations.cc
+++ b/horovod/common/operations.cc
@@ -1544,17 +1544,17 @@ void CheckForStalledTensors(HorovodGlobalState& state) {
     if (now - start_at > STALL_WARNING_TIME) {
       std::stringstream message;
       if (!preamble) {
-        LOG(WARNING) << "One or more tensors were submitted to be "
-                        "reduced, gathered or broadcasted by subset of ranks and "
-                        "are waiting for remainder of ranks for more than "
-                     << std::chrono::duration_cast<std::chrono::seconds>(
-                         STALL_WARNING_TIME)
-                         .count()
-                     << " seconds. "
-                     << "This may indicate that different ranks are trying to "
-                        "submit different tensors or that only subset of ranks is "
-                        "submitting tensors, which will cause deadlock. "
-                     << std::endl << "Stalled ops:" ;
+       message << "One or more tensors were submitted to be "
+                  "reduced, gathered or broadcasted by subset of ranks and "
+                  "are waiting for remainder of ranks for more than "
+               << std::chrono::duration_cast<std::chrono::seconds>(
+                   STALL_WARNING_TIME)
+                   .count()
+               << " seconds. "
+               << "This may indicate that different ranks are trying to "
+                  "submit different tensors or that only subset of ranks is "
+                  "submitting tensors, which will cause deadlock. "
+               << std::endl << "Stalled ops:" ;
         preamble = true;
       }
       message << tensor_name;
@@ -1664,8 +1664,10 @@ void BackgroundThreadLoop(HorovodGlobalState& state) {
   // Get MPI size to determine how many tensors to wait for before reducing.
   int size;
   MPI_Comm_size(state.mpi_comm, &size);
-  if (is_coordinator) LOG(INFO) << "Started Horovod with " << size << " processes";
-
+  if (is_coordinator) {
+    LOG(INFO) << "Started Horovod with " << size << " processes";
+  }
+  
   // Determine local rank by querying the local communicator.
   MPI_Comm local_comm;
   MPI_Comm_split_type(state.mpi_comm, MPI_COMM_TYPE_SHARED, 0, MPI_INFO_NULL,
@@ -1767,7 +1769,6 @@ void BackgroundThreadLoop(HorovodGlobalState& state) {
                  (size != local_size);
     state.param_manager.SetHierarchicalAllgather(value, true);
   }
-  
   // Set flag for hierarchical allreduce. Ignore if Horovod is running on a
   // single node.
   auto horovod_hierarchical_allreduce = std::getenv(HOROVOD_HIERARCHICAL_ALLREDUCE);

--- a/horovod/common/operations.cc
+++ b/horovod/common/operations.cc
@@ -1544,17 +1544,17 @@ void CheckForStalledTensors(HorovodGlobalState& state) {
     if (now - start_at > STALL_WARNING_TIME) {
       std::stringstream message;
       if (!preamble) {
-        LOG(WARNING) << "WARNING: One or more tensors were submitted to be "
-                     "reduced, gathered or broadcasted by subset of ranks and "
-                     "are waiting for remainder of ranks for more than "
-                  << std::chrono::duration_cast<std::chrono::seconds>(
+        LOG(WARNING) << "One or more tensors were submitted to be "
+                        "reduced, gathered or broadcasted by subset of ranks and "
+                        "are waiting for remainder of ranks for more than "
+                     << std::chrono::duration_cast<std::chrono::seconds>(
                          STALL_WARNING_TIME)
                          .count()
-                  << " seconds. "
-                  << "This may indicate that different ranks are trying to "
-                     "submit different tensors or that only subset of ranks is "
-                     "submitting tensors, which will cause deadlock. "
-                  << std::endl << "Stalled ops:" ;
+                     << " seconds. "
+                     << "This may indicate that different ranks are trying to "
+                        "submit different tensors or that only subset of ranks is "
+                        "submitting tensors, which will cause deadlock. "
+                     << std::endl << "Stalled ops:" ;
         preamble = true;
       }
       message << tensor_name;
@@ -1627,9 +1627,9 @@ void BackgroundThreadLoop(HorovodGlobalState& state) {
   if (is_mpi_initialized) {
     MPI_Query_thread(&provided);
     if (provided < MPI_THREAD_MULTIPLE) {
-      LOG(WARNING) << "WARNING: MPI has already been initialized without "
-                   "multi-threading support (MPI_THREAD_MULTIPLE). This will "
-                   "likely cause a segmentation fault.";
+      LOG(WARNING) << "MPI has already been initialized without "
+                      "multi-threading support (MPI_THREAD_MULTIPLE). This will "
+                      "likely cause a segmentation fault.";
     }
   } else {
     MPI_Init_thread(NULL, NULL, required, &provided);
@@ -1644,8 +1644,8 @@ void BackgroundThreadLoop(HorovodGlobalState& state) {
                    &work_group);
     MPI_Comm_create_group(MPI_COMM_WORLD, work_group, 0, &(state.mpi_comm));
     if (state.mpi_comm == MPI_COMM_NULL) {
-      LOG(WARNING) << "WARNING: Unable to create Horovod communicator, using "
-                   "MPI_COMM_WORLD instead.";
+      LOG(WARNING) << "Unable to create Horovod communicator, using "
+                      "MPI_COMM_WORLD instead.";
       state.mpi_comm = MPI_COMM_WORLD;
     }
     MPI_Group_free(&world_group);
@@ -1788,7 +1788,7 @@ void BackgroundThreadLoop(HorovodGlobalState& state) {
   if (is_coordinator && (state.param_manager.HierarchicalAllreduce()
               || state.param_manager.HierarchicalAllgather()) && !state.is_homogeneous) {
     LOG(WARNING)
-        << "WARNING: Using different number of ranks per node might cause "
+        << "Using different number of ranks per node might cause "
            "performance loss in hierarchical allgather and "
            "hierarchical allreduce. Consider assigning the same "
            "number of ranks to each node, or disabling hierarchical "

--- a/horovod/common/operations.cc
+++ b/horovod/common/operations.cc
@@ -2077,6 +2077,7 @@ bool RunLoopOnce(HorovodGlobalState& state, bool is_coordinator) {
       }
 
         response_list.add_responses(response);
+        LOG(DEBUG) << "Created response of size " << tensor_size;
       }
     }
 

--- a/horovod/common/operations.cc
+++ b/horovod/common/operations.cc
@@ -2046,11 +2046,11 @@ bool RunLoopOnce(HorovodGlobalState& state, bool is_coordinator) {
         auto response = responses.front();
         assert(response.tensor_names().size() == 1);
         responses.pop_front();
-
+        int64_t tensor_size = 0;
         if (response.response_type() == MPIResponse::ResponseType::ALLREDUCE) {
           // Attempt to add more responses to this fused response.
           auto& entry = state.tensor_table[response.tensor_names()[0]];
-          int64_t tensor_size = entry.tensor->size();
+          tensor_size = entry.tensor->size();
 
           while (!responses.empty()) {
             auto new_response = responses.front();

--- a/horovod/common/operations.cc
+++ b/horovod/common/operations.cc
@@ -1948,7 +1948,7 @@ bool RunLoopOnce(HorovodGlobalState& state, bool is_coordinator) {
     }
   }
 
-  if (!message_queue.empty()) LOG(DEBUG, state.rank) << "Sent " << message_queue.size() << " messages";
+  // if (!message_queue.empty()) LOG(DEBUG, state.rank) << "Sent " << message_queue.size() << " messages";
 
   // Flag indicating that the background thread should shut down.
   bool should_shut_down = state.shut_down;
@@ -2114,6 +2114,7 @@ bool RunLoopOnce(HorovodGlobalState& state, bool is_coordinator) {
     // the same operation.
     for (auto& response : response_list.responses()) {
       LOG(TRACE, state.rank) << "Performing " << response.tensor_names_string();
+      LOG(DEBUG, state.rank) << "Processing " << response.tensor_names().size() << " tensors";
       PerformOperation(state.tensor_table, response);
       LOG(TRACE, state.rank) << "Finished performing " << response.tensor_names_string();
     }

--- a/horovod/common/operations.cc
+++ b/horovod/common/operations.cc
@@ -1664,7 +1664,7 @@ void BackgroundThreadLoop(HorovodGlobalState& state) {
   // Get MPI size to determine how many tensors to wait for before reducing.
   int size;
   MPI_Comm_size(state.mpi_comm, &size);
-  LOG(INFO) << "Started Horovod with " << size << " processes";
+  if (is_coordinator) LOG(INFO) << "Started Horovod with " << size << " processes";
 
   // Determine local rank by querying the local communicator.
   MPI_Comm local_comm;
@@ -1803,7 +1803,7 @@ void BackgroundThreadLoop(HorovodGlobalState& state) {
                                    horovod_autotune_log != nullptr ? std::string(horovod_autotune_log) : "");
     state.param_manager.SetAutoTuning(true);
   }
-  LOG(INFO) << "Using fusion threshold of " << state.tensor_fusion_threshold;
+  if (is_coordinator) LOG(INFO) << "Using fusion threshold of " << state.tensor_fusion_threshold;
 
   // Initialize the tensor count table. No tensors are available yet.
   if (is_coordinator) {

--- a/horovod/common/parameter_manager.cc
+++ b/horovod/common/parameter_manager.cc
@@ -87,6 +87,9 @@ void ParameterManager::Initialize(int32_t rank, int32_t root_rank, MPI_Comm mpi_
   rank_ = rank;
   root_rank_ = root_rank;
   mpi_comm_ = mpi_comm;
+  if (rank_ == root_rank) {
+    LOG(INFO) << "Autotuner: Tunable params [hierarchical_allreduce,hierarchical_allgather,cycle_time_ms,tensor_fusion_threshold] score";
+  }
   if (rank_ == root_rank && !file_name.empty()) {
     file_.open(file_name, std::ios::out | std::ios::trunc);
     if (file_.good()) {
@@ -170,7 +173,7 @@ void ParameterManager::Tune(double score) {
     // Ignore this score as we're still warming up.
     warmup_remaining_--;
     if (rank_ == root_rank_) {
-      LOG(INFO) << "HOROVOD_AUTOTUNER: WARMUP DONE (" << warmup_remaining_ << " remaining)";
+      LOG(INFO) << "Autotuner: Warming up (" << warmup_remaining_ << " remaining)";
     }
   } else {
     // Log the last parameter values before updating.
@@ -245,7 +248,7 @@ void ParameterManager::Reset() {
 
 void ParameterManager::LogParameters(double score) {
   if (rank_ == root_rank_) {
-    LOG(INFO) << "HOROVOD_AUTOTUNER: ["
+    LOG(INFO) << "Autotuner: ["
               << hierarchical_allreduce_.Value() << ", "
               << hierarchical_allgather_.Value() << ", "
               << joint_params_.Value(cycle_time_ms) << " ms, "

--- a/horovod/common/parameter_manager.cc
+++ b/horovod/common/parameter_manager.cc
@@ -14,6 +14,7 @@
 // =============================================================================
 
 #include "parameter_manager.h"
+#include "logging.h"
 
 #include <algorithm>
 #include <cmath>
@@ -169,7 +170,7 @@ void ParameterManager::Tune(double score) {
     // Ignore this score as we're still warming up.
     warmup_remaining_--;
     if (rank_ == root_rank_) {
-      std::cerr << "HOROVOD_AUTOTUNER: WARMUP DONE (" << warmup_remaining_ << " remaining)" << std::endl;
+      LOG(INFO) << "HOROVOD_AUTOTUNER: WARMUP DONE (" << warmup_remaining_ << " remaining)";
     }
   } else {
     // Log the last parameter values before updating.
@@ -244,13 +245,12 @@ void ParameterManager::Reset() {
 
 void ParameterManager::LogParameters(double score) {
   if (rank_ == root_rank_) {
-    std::cerr << "HOROVOD_AUTOTUNER: ["
+    LOG(INFO) << "HOROVOD_AUTOTUNER: ["
               << hierarchical_allreduce_.Value() << ", "
               << hierarchical_allgather_.Value() << ", "
               << joint_params_.Value(cycle_time_ms) << " ms, "
               << joint_params_.Value(fusion_buffer_threshold_mb) << " mb] "
-              << score
-              << std::endl;
+              << score;
     if (writing_ && file_.good()) {
       file_ << hierarchical_allreduce_.Value() << ","
             << hierarchical_allgather_.Value() << ","
@@ -264,13 +264,12 @@ void ParameterManager::LogParameters(double score) {
 
 void ParameterManager::LogBestParameters() {
   if (rank_ == root_rank_) {
-    std::cerr << "HOROVOD_AUTOTUNER: BEST ["
+    LOG(INFO) << "HOROVOD_AUTOTUNER: BEST ["
               << hierarchical_allreduce_.BestValue() << ", "
               << hierarchical_allgather_.BestValue() << ", "
               << joint_params_.BestValue(cycle_time_ms) << " ms, "
               << joint_params_.BestValue(fusion_buffer_threshold_mb) << " mb] "
-              << hierarchical_allreduce_.BestScore()
-              << std::endl;
+              << hierarchical_allreduce_.BestScore();
     if (writing_ && file_.good()) {
       file_ << hierarchical_allreduce_.BestValue() << ","
             << hierarchical_allgather_.BestValue() << ","

--- a/horovod/common/parameter_manager.cc
+++ b/horovod/common/parameter_manager.cc
@@ -267,7 +267,7 @@ void ParameterManager::LogParameters(double score) {
 
 void ParameterManager::LogBestParameters() {
   if (rank_ == root_rank_) {
-    LOG(INFO) << "HOROVOD_AUTOTUNER: BEST ["
+    LOG(INFO) << "Autotuner: Best params ["
               << hierarchical_allreduce_.BestValue() << ", "
               << hierarchical_allgather_.BestValue() << ", "
               << joint_params_.BestValue(cycle_time_ms) << " ms, "

--- a/horovod/common/timeline.cc
+++ b/horovod/common/timeline.cc
@@ -17,6 +17,7 @@
 #include <cassert>
 
 #include "timeline.h"
+#include "logging.h"
 
 namespace horovod {
 namespace common {
@@ -29,8 +30,8 @@ void Timeline::Initialize(std::string file_name) {
     start_time_ = last_flush_time_ = std::chrono::steady_clock::now();
     initialized_ = true;
   } else {
-    std::cerr << "WARNING: Error opening the Horovod Timeline file "
-              << file_name << ", will not write a timeline." << std::endl;
+    LOG(ERROR) << "Error opening the Horovod Timeline file "
+               << file_name << ", will not write a timeline.";
   }
 }
 
@@ -89,9 +90,8 @@ void Timeline::WriteEvent(const std::string& tensor_name, const char phase,
   }
 
   if (!file_.good()) {
-    std::cerr << "WARNING: Error writing to the Horovod Timeline after it was "
-                 "successfully opened, will stop writing the timeline."
-              << std::endl;
+    LOG(ERROR) << "Error writing to the Horovod Timeline after it was "
+                  "successfully opened, will stop writing the timeline.";
   }
 }
 

--- a/setup.py
+++ b/setup.py
@@ -435,7 +435,8 @@ def get_common_options(build_ext):
                'horovod/common/parameter_manager.cc',
                'horovod/common/timeline.cc',
                'horovod/common/optim/bayesian_optimization.cc',
-               'horovod/common/optim/gaussian_process.cc']
+               'horovod/common/optim/gaussian_process.cc',
+               'horovod/common/logging.cc']
     COMPILE_FLAGS = cpp_flags + shlex.split(mpi_flags)
     LINK_FLAGS = link_flags + shlex.split(mpi_flags)
     LIBRARY_DIRS = []


### PR DESCRIPTION
Adds a logging framework with different levels, which the user can activate by using the environment variable  `HOROVOD_LOG_LEVEL`. It takes the values as follows:
`fatal`, `error`, `warning` : Warnings like stalled tensors, etc **(default)**
`info`: Logs the configuration and initialization and shutdown,etc
`debug`: Logs how many tensors are being fused, what size, etc
`trace` : Logs names of tensors being reduced in addition to the above

This PR also adds some logs at the appropriate level. The intention is to allow users (or developers) to take a closer look at Horovod operations when they face a crash or hang. There is no performance effect to this (unless you turn on trace maybe, but even that was barely noticeable in my experience). If you think the level of some statement should be adjusted, please let me know. 

Printing logs and controlling the levels should be useful for developers as well when developing a new feature.  This adds two macros for logging which developers can use.
- LOG(INFO) << "message";
- LOG(INFO, rank) << "message";

The output is similar to how TensorFlow logs operations.

Sample output (the [1] refers to rank1)
```
[2018-12-01 00:12:30.893028: I horovod/common/operations.cc:1498] Started Horovod with 8 processes
[2018-12-01 00:12:30.893390: I horovod/common/operations.cc:1629] [1]: Horovod Initialized
[2018-12-01 00:12:30.893397: I horovod/common/operations.cc:1629] [2]: Horovod Initialized
[2018-12-01 00:12:30.893399: I horovod/common/operations.cc:1629] [3]: Horovod Initialized
[2018-12-01 00:12:30.893399: I horovod/common/operations.cc:1629] [4]: Horovod Initialized
[2018-12-01 00:12:30.893393: I horovod/common/operations.cc:1629] [5]: Horovod Initialized
[2018-12-01 00:12:30.893397: I horovod/common/operations.cc:1629] [6]: Horovod Initialized
[2018-12-01 00:12:30.893406: I horovod/common/operations.cc:1629] [7]: Horovod Initialized
[2018-12-01 00:12:30.893393: I horovod/common/operations.cc:1619] Using fusion threshold of 16777216
[2018-12-01 00:12:30.893424: I horovod/common/operations.cc:1629] [0]: Horovod Initialized
[2018-12-01 00:11:18.020152: D horovod/common/operations.cc:1758] [6]: Sent 5 messages
[2018-12-01 00:11:18.024032: D horovod/common/operations.cc:1758] [4]: Sent 10 messages
[2018-12-01 00:11:18.024160: D horovod/common/operations.cc:1758] [2]: Sent 5 messages
[2018-12-01 00:11:18.024365: D horovod/common/operations.cc:1887] Created response of size 12410784
[2018-12-01 00:11:18.024402: D horovod/common/operations.cc:1887] Created response of size 9441280
```
There's also another environment variable which disables the printing of the time. (HOROVOD_LOG_HIDE_TIME=1)
The output would then look like:
```
[I horovod/common/operations.cc:1498] Started Horovod with 8 processes
[I horovod/common/operations.cc:1619] Using fusion threshold of 16777216
[I horovod/common/operations.cc:1629] [0]: Horovod Initialized
[I horovod/common/operations.cc:1629] [1]: Horovod Initialized
[I horovod/common/operations.cc:1629] [2]: Horovod Initialized
[I horovod/common/operations.cc:1629] [3]: Horovod Initialized
[I horovod/common/operations.cc:1629] [4]: Horovod Initialized
[I horovod/common/operations.cc:1629] [5]: Horovod Initialized
[I horovod/common/operations.cc:1629] [6]: Horovod Initialized
[I horovod/common/operations.cc:1629] [7]: Horovod Initialized
```