### PR TITLE
Removed depreciated tensorflow dataset APIs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -111,6 +111,12 @@ script:
   # run unit tests
   - docker exec ${CONTAINER} /bin/sh -c "pip install pytest && cd /horovod/test && ${MPIRUN} pytest -v"
 
+  # hack for compatibility of MNIST example with tf 1.1.0
+  - |
+    if [[ ${TF_PACKAGE} == "tensorflow==1.1.0" ]]; then
+      docker exec ${CONTAINER} /bin/sh -c "sed -i \"s/from tensorflow import keras/from tensorflow.contrib import keras/\" /horovod/examples/tensorflow_mnist.py"
+    fi
+
   # hack TensorFlow MNIST example to be smaller
   - docker exec ${CONTAINER} /bin/sh -c "sed -i \"s/last_step=20000/last_step=100/\" /horovod/examples/tensorflow_mnist.py"
 

--- a/examples/tensorflow_mnist.py
+++ b/examples/tensorflow_mnist.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-# !/usr/bin/env python
+#!/usr/bin/env python
 
 import shutil
 import os

--- a/examples/tensorflow_mnist.py
+++ b/examples/tensorflow_mnist.py
@@ -92,6 +92,9 @@ def main(_):
     (x_train, y_train), (x_test, y_test) = \
         keras.datasets.mnist.load_data(dataset_dir)
 
+    # The shape of downloaded data is (-1, 28, 28), hence we need to reshape it
+    # into (-1, 784) to feed into our network. Also, need to normalize the
+    # features between 0 and 1.
     x_train = np.reshape(x_train, (-1, 784)) / 255.0
     x_test = np.reshape(x_test, (-1, 784)) / 255.0
 

--- a/examples/tensorflow_mnist.py
+++ b/examples/tensorflow_mnist.py
@@ -99,9 +99,8 @@ def main(_):
         datadir_base = os.path.expanduser(cache_dir)
         datadir = os.path.join(datadir_base, "datasets")
         shutil.rmtree(datadir)
-        (x_train, y_train), (
-            x_test, y_test) = keras.datasets.mnist.load_data(
-            'MNIST-data-%d' % hvd.rank())
+        (x_train, y_train), (x_test, y_test) = \
+            keras.datasets.mnist.load_data('MNIST-data-%d' % hvd.rank())
 
     x_train = np.reshape(x_train, (-1, 784)) / 255.0
     x_test = np.reshape(x_test, (-1, 784)) / 255.0

--- a/examples/tensorflow_mnist_estimator.py
+++ b/examples/tensorflow_mnist_estimator.py
@@ -142,7 +142,7 @@ def main(unused_argv):
     except OSError as ex:
         # When running tests, if dataset is previously downloaded, it may cause
         # the tests to fail. In this case, we need to remove the dataset cache
-        # folder first and download the dataset again.
+        # folder first and download the dataset again. 
         cache_dir = os.path.join(os.path.expanduser('~'), '.keras')
         datadir_base = os.path.expanduser(cache_dir)
         datadir = os.path.join(datadir_base, "datasets")

--- a/examples/tensorflow_mnist_estimator.py
+++ b/examples/tensorflow_mnist_estimator.py
@@ -145,7 +145,9 @@ def main(unused_argv):
     (train_data, train_labels), (eval_data, eval_labels) = \
         keras.datasets.mnist.load_data(dataset_dir)
 
-    # reshape the features and normalize them between 0 and 1
+    # The shape of downloaded data is (-1, 28, 28), hence we need to reshape it
+    # into (-1, 784) to feed into our network. Also, need to normalize the
+    # features between 0 and 1.
     train_data = np.reshape(train_data, (-1, 784)) / 255.0
     eval_data = np.reshape(eval_data, (-1, 784)) / 255.0
 

--- a/examples/tensorflow_mnist_estimator.py
+++ b/examples/tensorflow_mnist_estimator.py
@@ -18,7 +18,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-
+import os
 import numpy as np
 import tensorflow as tf
 import horovod.tensorflow as hvd
@@ -140,23 +140,10 @@ def main(unused_argv):
     hvd.init()
 
     # Load training and eval data
-
-    # When running with MPI and with more than 1 process, all the processes try
-    # to download the data and this can cause a race condition.
-    # Multiple processes might simultaneously check if the dataset folder
-    # exists and then try to create the folder and download the data. However,
-    # one of them only succeeds, and the rest fail with an os IOError.
-    for i in range(5):
-        try:
-            (train_data, train_labels), (eval_data, eval_labels) = \
-                keras.datasets.mnist.load_data('MNIST-data-%d' % hvd.rank())
-        except OSError:
-            continue  # retrying
-        else:
-            break
-    else:
-        exit(1)
-
+    dataset_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)),
+                               'MNIST-data-%d' % hvd.rank())
+    (train_data, train_labels), (eval_data, eval_labels) = \
+        keras.datasets.mnist.load_data(dataset_dir)
 
     # reshape the features and normalize them between 0 and 1
     train_data = np.reshape(train_data, (-1, 784)) / 255.0

--- a/examples/tensorflow_mnist_estimator.py
+++ b/examples/tensorflow_mnist_estimator.py
@@ -158,7 +158,7 @@ def main(unused_argv):
             'MNIST-data-%d' % hvd.rank())
 
     # reshape the features and normalize them between 0 and 1
-    train_data = np.reshape(train_data, (-1, 784)) / 255.0 
+    train_data = np.reshape(train_data, (-1, 784)) / 255.0
     eval_data = np.reshape(eval_data, (-1, 784)) / 255.0
 
     # Horovod: pin GPU to be used to process local rank (one GPU per process)

--- a/examples/tensorflow_mnist_estimator.py
+++ b/examples/tensorflow_mnist_estimator.py
@@ -153,9 +153,8 @@ def main(unused_argv):
         datadir_base = os.path.expanduser(cache_dir)
         datadir = os.path.join(datadir_base, "datasets")
         shutil.rmtree(datadir)
-        (train_data, train_labels), (
-            eval_data, eval_labels) = keras.datasets.mnist.load_data(
-            'MNIST-data-%d' % hvd.rank())
+        (train_data, train_labels), (eval_data, eval_labels) = \
+            keras.datasets.mnist.load_data('MNIST-data-%d' % hvd.rank())
 
     # reshape the features and normalize them between 0 and 1
     train_data = np.reshape(train_data, (-1, 784)) / 255.0

--- a/examples/tensorflow_mnist_estimator.py
+++ b/examples/tensorflow_mnist_estimator.py
@@ -158,7 +158,7 @@ def main(unused_argv):
             'MNIST-data-%d' % hvd.rank())
 
     # reshape the features and normalize them between 0 and 1
-    train_data = np.reshape(train_data, (-1, 784)) / 255.0
+    train_data = np.reshape(train_data, (-1, 784)) / 255.0 
     eval_data = np.reshape(eval_data, (-1, 784)) / 255.0
 
     # Horovod: pin GPU to be used to process local rank (one GPU per process)

--- a/examples/tensorflow_mnist_estimator.py
+++ b/examples/tensorflow_mnist_estimator.py
@@ -21,10 +21,16 @@ from __future__ import print_function
 import os
 import shutil
 
-import keras
 import numpy as np
 import tensorflow as tf
 import horovod.tensorflow as hvd
+
+from distutils.version import LooseVersion
+
+if LooseVersion(tf.__version__) >= LooseVersion("1.4.0"):
+    from tensorflow import keras
+else:
+    from tensorflow.contrib import keras
 
 tf.logging.set_verbosity(tf.logging.INFO)
 
@@ -142,7 +148,7 @@ def main(unused_argv):
     except OSError as ex:
         # When running tests, if dataset is previously downloaded, it may cause
         # the tests to fail. In this case, we need to remove the dataset cache
-        # folder first and download the dataset again. 
+        # folder first and download the dataset again.
         cache_dir = os.path.join(os.path.expanduser('~'), '.keras')
         datadir_base = os.path.expanduser(cache_dir)
         datadir = os.path.join(datadir_base, "datasets")
@@ -152,8 +158,8 @@ def main(unused_argv):
             'MNIST-data-%d' % hvd.rank())
 
     # reshape the features and normalize them between 0 and 1
-    train_data = np.reshape(train_data, (-1, 784)) / 255
-    eval_data = np.reshape(eval_data, (-1, 784)) / 255
+    train_data = np.reshape(train_data, (-1, 784)) / 255.0
+    eval_data = np.reshape(eval_data, (-1, 784)) / 255.0
 
     # Horovod: pin GPU to be used to process local rank (one GPU per process)
     config = tf.ConfigProto()

--- a/examples/tensorflow_mnist_estimator.py
+++ b/examples/tensorflow_mnist_estimator.py
@@ -18,10 +18,13 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import os
+import shutil
+
+import keras
 import numpy as np
 import tensorflow as tf
 import horovod.tensorflow as hvd
-learn = tf.contrib.learn
 
 tf.logging.set_verbosity(tf.logging.INFO)
 
@@ -78,7 +81,8 @@ def cnn_model_fn(features, labels, mode):
     # Densely connected layer with 1024 neurons
     # Input Tensor Shape: [batch_size, 7 * 7 * 64]
     # Output Tensor Shape: [batch_size, 1024]
-    dense = tf.layers.dense(inputs=pool2_flat, units=1024, activation=tf.nn.relu)
+    dense = tf.layers.dense(inputs=pool2_flat, units=1024,
+                            activation=tf.nn.relu)
 
     # Add dropout operation; 0.6 probability that element will be kept
     dropout = tf.layers.dropout(
@@ -116,7 +120,8 @@ def cnn_model_fn(features, labels, mode):
         train_op = optimizer.minimize(
             loss=loss,
             global_step=tf.train.get_global_step())
-        return tf.estimator.EstimatorSpec(mode=mode, loss=loss, train_op=train_op)
+        return tf.estimator.EstimatorSpec(mode=mode, loss=loss,
+                                          train_op=train_op)
 
     # Add evaluation metrics (for EVAL mode)
     eval_metric_ops = {
@@ -131,11 +136,24 @@ def main(unused_argv):
     hvd.init()
 
     # Load training and eval data
-    mnist = learn.datasets.mnist.read_data_sets('MNIST-data-%d' % hvd.rank())
-    train_data = mnist.train.images  # Returns np.array
-    train_labels = np.asarray(mnist.train.labels, dtype=np.int32)
-    eval_data = mnist.test.images  # Returns np.array
-    eval_labels = np.asarray(mnist.test.labels, dtype=np.int32)
+    try:
+        (train_data, train_labels), (eval_data, eval_labels) = \
+            keras.datasets.mnist.load_data('MNIST-data-%d' % hvd.rank())
+    except OSError as ex:
+        # When running tests, if dataset is previously downloaded, it may cause
+        # the tests to fail. In this case, we need to remove the dataset cache
+        # folder first and download the dataset again.
+        cache_dir = os.path.join(os.path.expanduser('~'), '.keras')
+        datadir_base = os.path.expanduser(cache_dir)
+        datadir = os.path.join(datadir_base, "datasets")
+        shutil.rmtree(datadir)
+        (train_data, train_labels), (
+            eval_data, eval_labels) = keras.datasets.mnist.load_data(
+            'MNIST-data-%d' % hvd.rank())
+
+    # reshape the features and normalize them between 0 and 1
+    train_data = np.reshape(train_data, (-1, 784)) / 255
+    eval_data = np.reshape(eval_data, (-1, 784)) / 255
 
     # Horovod: pin GPU to be used to process local rank (one GPU per process)
     config = tf.ConfigProto()


### PR DESCRIPTION
Some of the examples were using depreciated tensorflow APIs to load the data and these changes fix the problem.

- updated the MNIST Dataset API
- updated ModeKey

Issue #673 