### PR TITLE
Keras: pass optimizer parameters as dictionary instead of **kwargs

### DIFF
--- a/horovod/_keras/__init__.py
+++ b/horovod/_keras/__init__.py
@@ -21,7 +21,7 @@ def create_distributed_optimizer(keras, optimizer, name, device_dense, device_sp
                                  compression, sparse_as_dense):
     class _DistributedOptimizer(keras.optimizers.Optimizer):
         def __init__(self, name, device_dense, device_sparse, compression, sparse_as_dense,
-                     **kwargs):
+                     config):
             if name is None:
                 name = "Distributed%s" % self.__class__.__base__.__name__
             self._name = name
@@ -29,7 +29,7 @@ def create_distributed_optimizer(keras, optimizer, name, device_dense, device_sp
             self._device_sparse = device_sparse
             self._compression = compression
             self._sparse_as_dense = sparse_as_dense
-            super(self.__class__, self).__init__(**kwargs)
+            super(self.__class__, self).__init__(**config)
 
         def get_gradients(self, loss, params):
             """
@@ -67,7 +67,7 @@ def create_distributed_optimizer(keras, optimizer, name, device_dense, device_sp
     cls = type(optimizer.__class__.__name__, (optimizer.__class__,),
                dict(_DistributedOptimizer.__dict__))
     return cls(name, device_dense, device_sparse, compression, sparse_as_dense,
-               **optimizer.get_config())
+               optimizer.get_config())
 
 
 def broadcast_global_variables(backend, root_rank):


### PR DESCRIPTION
Keras added `name` argument as an optimizer configuration parameter which clashes with one of the arguments that we pass ourselves. Switching `**kwargs` -> `config` to avoid this issue.