### PR TITLE
Have TensorFlow handle memcpy for Hierarchical Allgather

### DIFF
--- a/horovod/tensorflow/mpi_ops.cc
+++ b/horovod/tensorflow/mpi_ops.cc
@@ -361,7 +361,7 @@ public:
 
 REGISTER_KERNEL_BUILDER(Name("HorovodAllgather").Device(DEVICE_CPU),
                         HorovodAllgatherOp);
-#if HAVE_CUDA
+#if HOROVOD_GPU_ALLGATHER
 REGISTER_KERNEL_BUILDER(Name("HorovodAllgather").Device(DEVICE_GPU),
                         HorovodAllgatherOp);
 #endif


### PR DESCRIPTION
The proposal is to revert the change of using PerformOperation() to do memory copy, since it's a blocking operation, unlike memory copy performed by TensorFlow.

I've seen 10%-15% performance improvement for a small embedding + MLP model with 2M parameters.  Each Allgather operation turns from 0.2ms to 0.035ms each.

@karakusc, could you try and see if this introduces any significant regression for large tensor use case?

Before the change:
![image](https://user-images.githubusercontent.com/16640218/50468060-d2366e80-095a-11e9-8242-24d128bd1dd3.png)
[horovod-timeline-v1.json.zip](https://github.com/uber/horovod/files/2711596/horovod-timeline-v1.json.zip)

After the change:
![image](https://user-images.githubusercontent.com/16640218/50468063-d5315f00-095a-11e9-9626-6870454b86cf.png)
[horovod-timeline-v2.json.zip](https://github.com/uber/horovod/files/2711595/horovod-timeline-v2.json.zip)