### PR TITLE
Use p.grad directly w/o .data

### DIFF
--- a/horovod/torch/__init__.py
+++ b/horovod/torch/__init__.py
@@ -90,7 +90,7 @@ class _DistributedOptimizer(torch.optim.Optimizer):
 
     def _allreduce_grad_async(self, p):
         name = self._parameter_names.get(p)
-        tensor = p.grad.data
+        tensor = p.grad
         tensor_compressed, ctx = self._compression.compress(tensor)
 
         handle = allreduce_async_(tensor_compressed, average=True, name=name)
@@ -128,7 +128,7 @@ class _DistributedOptimizer(torch.optim.Optimizer):
         for p, (handle, _) in self._handles.items():
             output = synchronize(handle)
             self._allreduce_delay[p] = self.backward_passes_per_step
-            p.grad.data.set_(self._compression.decompress(output, ctx))
+            p.grad.set_(self._compression.decompress(output, ctx))
         self._handles.clear()
 
     def step(self, closure=None):


### PR DESCRIPTION
Fix latest PyTorch breaking change:
```
In [1]: import torch

In [2]: t = torch.tensor([1.0,2.0,3.0], requires_grad=True)

In [3]: t.backward(t * 2)

In [4]: t.grad.data.set_(torch.tensor([1.,2.,3.]))
---------------------------------------------------------------------------
RuntimeError                              Traceback (most recent call last)
<ipython-input-4-ba5a3de57fa0> in <module>()
----> 1 t.grad.data.set_(torch.tensor([1.,2.,3.]))

RuntimeError: set_storage is not allowed on Tensor created from .data or .detach()
```
