### PR TITLE
Filter warnings to avoid Travis CI failure

### DIFF
--- a/test/test_keras.py
+++ b/test/test_keras.py
@@ -26,6 +26,7 @@ import numpy as np
 import os
 import tempfile
 import tensorflow as tf
+import warnings
 
 import horovod.keras as hvd
 
@@ -37,6 +38,7 @@ class KerasTests(tf.test.TestCase):
 
     def __init__(self, *args, **kwargs):
         super(KerasTests, self).__init__(*args, **kwargs)
+        warnings.simplefilter('module')
 
     def test_sparse_as_dense(self):
         hvd.init()

--- a/test/test_spark.py
+++ b/test/test_spark.py
@@ -23,6 +23,7 @@ import time
 import torch
 import traceback
 import unittest
+import warnings
 
 import horovod.spark
 import horovod.torch as hvd
@@ -32,6 +33,11 @@ class SparkTests(unittest.TestCase):
     """
     Tests for horovod.spark.run().
     """
+
+    def __init__(self):
+        super(SparkTests, self).__init__()
+        warnings.simplefilter('module')
+
     def run(self, result=None):
         if os.environ.get('OMPI_COMM_WORLD_RANK', '0') != '0':
             # Running in MPI as a rank > 0, ignore.

--- a/test/test_spark.py
+++ b/test/test_spark.py
@@ -34,8 +34,8 @@ class SparkTests(unittest.TestCase):
     Tests for horovod.spark.run().
     """
 
-    def __init__(self):
-        super(SparkTests, self).__init__()
+    def __init__(self, *args, **kwargs):
+        super(SparkTests, self).__init__(*args, **kwargs)
         warnings.simplefilter('module')
 
     def run(self, result=None):

--- a/test/test_tensorflow.py
+++ b/test/test_tensorflow.py
@@ -23,13 +23,13 @@ from __future__ import print_function
 import itertools
 import numpy as np
 import tensorflow as tf
+from horovod.tensorflow.util import _executing_eagerly, _has_eager
+from tensorflow.python.framework import ops
+import warnings
 
 import horovod.tensorflow as hvd
 
 from common import mpi_env_rank_and_size
-
-from horovod.tensorflow.util import _executing_eagerly, _has_eager
-from tensorflow.python.framework import ops
 
 config = tf.ConfigProto()
 config.gpu_options.allow_growth = True
@@ -38,6 +38,7 @@ if _has_eager:
     from tensorflow.python.framework.test_util import run_all_in_graph_and_eager_modes
     tf.enable_eager_execution(config=config)
 
+
 class MPITests(tf.test.TestCase):
     """
     Tests for ops in horovod.tensorflow.
@@ -45,6 +46,7 @@ class MPITests(tf.test.TestCase):
 
     def __init__(self, *args, **kwargs):
         super(MPITests, self).__init__(*args, **kwargs)
+        warnings.simplefilter('module')
         if _has_eager:
             self.tfe = tf.contrib.eager
 

--- a/test/test_tensorflow_keras.py
+++ b/test/test_tensorflow_keras.py
@@ -21,6 +21,7 @@ from __future__ import print_function
 
 import tensorflow as tf
 import numpy as np
+import warnings
 
 from distutils.version import LooseVersion
 if LooseVersion(tf.__version__) >= LooseVersion("1.4.0"):
@@ -40,6 +41,7 @@ class TfKerasTests(tf.test.TestCase):
 
     def __init__(self, *args, **kwargs):
         super(TfKerasTests, self).__init__(*args, **kwargs)
+        warnings.simplefilter('module')
 
     def test_train_model(self):
         hvd.init()

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -41,8 +41,8 @@ class TorchTests(unittest.TestCase):
     Tests for ops in horovod.torch.
     """
 
-    def __init__(self):
-        super(TorchTests, self).__init__()
+    def __init__(self, *args, **kwargs):
+        super(TorchTests, self).__init__(*args, **kwargs)
         warnings.simplefilter('module')
 
     def convert_cpu_fp16_to_fp32(self, *values):

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -27,6 +27,7 @@ import tempfile
 import torch
 import torch.nn.functional as F
 import unittest
+import warnings
 
 import horovod.torch as hvd
 
@@ -39,6 +40,10 @@ class TorchTests(unittest.TestCase):
     """
     Tests for ops in horovod.torch.
     """
+
+    def __init__(self):
+        super(TorchTests, self).__init__()
+        warnings.simplefilter('module')
 
     def convert_cpu_fp16_to_fp32(self, *values):
         # PyTorch doesn't support any CPU ops on FP16 tensors.


### PR DESCRIPTION
We have so many deprecation warnings because of old TensorFlow/PyTorch, that Travis CI fails, e.g. https://api.travis-ci.org/v3/job/479219817/log.txt