### PR TITLE
Make duplicate name test more robust

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -121,6 +121,9 @@ script:
     fi
 
 
+  # prepare ~/.keras folder to avoid race condition
+  - docker exec ${CONTAINER} /bin/sh -c "mkdir -p ~/.keras"
+
   # run unit tests
   - docker exec ${CONTAINER} /bin/sh -c "pip install pytest && cd /horovod/test && (echo test_*.py | xargs -n 1 ${MPIRUN} pytest -v)"
 

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -368,7 +368,8 @@ class TorchTests(unittest.TestCase):
 
         hvd.allreduce_async(tensor, name='duplicate_name')
         try:
-            hvd.allreduce_async(tensor, name='duplicate_name')
+            for i in range(10):
+                hvd.allreduce_async(tensor, name='duplicate_name')
             assert False, 'hvd.allreduce_async did not throw error'
         except (torch.FatalError, ValueError):
             pass
@@ -560,7 +561,8 @@ class TorchTests(unittest.TestCase):
 
         hvd.allgather_async(tensor, name='duplicate_name')
         try:
-            hvd.allgather_async(tensor, name='duplicate_name')
+            for i in range(10):
+                hvd.allgather_async(tensor, name='duplicate_name')
             assert False, 'hvd.allgather_async did not throw error'
         except (torch.FatalError, ValueError):
             pass
@@ -757,7 +759,8 @@ class TorchTests(unittest.TestCase):
 
         hvd.broadcast_async(tensor, root_rank=0, name='duplicate_name')
         try:
-            hvd.broadcast_async(tensor, root_rank=0, name='duplicate_name')
+            for i in range(10):
+                hvd.broadcast_async(tensor, root_rank=0, name='duplicate_name')
             assert False, 'hvd.broadcast_async did not throw error'
         except (torch.FatalError, ValueError):
             pass


### PR DESCRIPTION
Make situation where Horovod can actually finish allreduce operation before the next one is enqueued less likely.  With default 5ms timeout, we should not see all 10 loop iterations succeed.