### PR TITLE
Optimized vectors and post-increments. [Refactored for Performance]

### DIFF
--- a/horovod/common/common.cc
+++ b/horovod/common/common.cc
@@ -73,7 +73,7 @@ void TensorShape::AppendShape(TensorShape& other) {
 const std::string TensorShape::DebugString() const {
   std::stringstream args;
   args << "[";
-  for (auto it = shape_.begin(); it != shape_.end(); it++) {
+  for (auto it = shape_.begin(); it != shape_.end(); ++it) {
     if (it != shape_.begin()) {
       args << ", ";
     }

--- a/horovod/common/mpi_message.cc
+++ b/horovod/common/mpi_message.cc
@@ -394,6 +394,7 @@ void MPIResponseList::SerializeToString(MPIResponseList& response_list,
   // FlatBuffers must be built bottom-up.
   flatbuffers::FlatBufferBuilder builder(1024);
   std::vector<flatbuffers::Offset<wire::MPIResponse>> responses;
+  responses.reserve(response_list.responses().size());
   for (const auto& resp : response_list.responses()) {
     flatbuffers::Offset<wire::MPIResponse> resp_obj;
     MPIResponse_SerializeToWire(resp, builder, resp_obj);

--- a/horovod/common/mpi_message.cc
+++ b/horovod/common/mpi_message.cc
@@ -204,6 +204,7 @@ void MPIRequestList::SerializeToString(const MPIRequestList& request_list,
   // FlatBuffers must be built bottom-up.
   flatbuffers::FlatBufferBuilder builder(1024);
   std::vector<flatbuffers::Offset<wire::MPIRequest>> requests;
+  requests.reserve(request_list.requests().size());
   for (const auto& req : request_list.requests()) {
     flatbuffers::Offset<wire::MPIRequest> req_obj;
     MPIRequest_SerializeToWire(req, builder, req_obj);

--- a/horovod/common/operations.cc
+++ b/horovod/common/operations.cc
@@ -851,7 +851,7 @@ void PerformOperation(TensorTable& tensor_table, MPIResponse response) {
 
     auto* recvcounts = new int[horovod_global.size]();
     auto* displcmnts = new int[horovod_global.size]();
-    
+
     for (size_t ec = 0; ec < entries.size(); ++ec) {
       entry_component_sizes[ec] = new int64_t[horovod_global.size]();
       entry_component_offsets[ec] = new int64_t[horovod_global.size]();

--- a/horovod/common/operations.cc
+++ b/horovod/common/operations.cc
@@ -1096,7 +1096,7 @@ void PerformOperation(TensorTable& tensor_table, MPIResponse response) {
       delete[] recvcounts;
       delete[] displcmnts;
 
-      for (size_t ec = 0; ec < entries.size(); ++ec {
+      for (size_t ec = 0; ec < entries.size(); ++ec) {
         delete[] entry_component_sizes[ec];
         delete[] entry_component_offsets[ec];
       }
@@ -1942,8 +1942,6 @@ void BackgroundThreadLoop(HorovodGlobalState& state) {
   // Notify all outstanding operations that Horovod has been shut down
   // and clear up the tensor table and message queue.
   std::vector<StatusCallback> callbacks;
-  // we know (# of elements put) == (size of tensor_table map).
-  callbacks.reserve(state.tensor_table.size()); 
   {
     std::lock_guard<std::mutex> guard(state.mutex);
     for (auto& e : state.tensor_table) {

--- a/horovod/common/optim/bayesian_optimization.cc
+++ b/horovod/common/optim/bayesian_optimization.cc
@@ -62,12 +62,12 @@ void BayesianOptimization::AddSample(const Eigen::VectorXd& x, const Eigen::Vect
 VectorXd BayesianOptimization::NextSample() {
   // Matrices are immutable and must be regenerated each time a new sample is added.
   MatrixXd x_sample(x_samples_.size(), d_);
-  for (unsigned int i = 0; i < x_samples_.size(); i++) {
+  for (unsigned int i = 0; i < x_samples_.size(); ++i) {
     x_sample.row(i) = x_samples_[i];
   }
 
   MatrixXd y_sample(y_samples_.size(), 1);
-  for (unsigned int i = 0; i < y_samples_.size(); i++) {
+  for (unsigned int i = 0; i < y_samples_.size(); ++i) {
     y_sample.row(i) = y_samples_[i];
   }
 
@@ -106,10 +106,10 @@ VectorXd BayesianOptimization::ProposeLocation(const MatrixXd& x_sample, const M
   // Optimize with random restarts to avoid getting stuck in local minimum.
   VectorXd x_next = VectorXd::Zero(d_);
   double fx_min = std::numeric_limits<double>::max();
-  for (int i = 0; i < n_restarts; i++) {
+  for (int i = 0; i < n_restarts; ++i) {
     // Generate a random starting point by drawing from our bounded distributions.
     VectorXd x = VectorXd::Zero(d_);
-    for (unsigned int j = 0; j < d_; j++) {
+    for (unsigned int j = 0; j < d_; ++j) {
       x[j] = dists_[j](gen_);
     }
 
@@ -168,7 +168,7 @@ VectorXd BayesianOptimization::ExpectedImprovement(const MatrixXd& x, const Matr
 }
 
 bool BayesianOptimization::CheckBounds(const Eigen::VectorXd& x) {
-  for (int i = 0; i < x.size(); i++) {
+  for (int i = 0; i < x.size(); ++i) {
     if (x[i] < bounds_[i].first || x[i] > bounds_[i].second) {
       return false;
     }

--- a/horovod/common/optim/gaussian_process.cc
+++ b/horovod/common/optim/gaussian_process.cc
@@ -33,7 +33,7 @@ namespace common {
 
 // Returns true if any of the elements in the vectors is not a number.
 bool isnan(const VectorXd& x) {
-  for (int i = 0; i < x.size(); i++) {
+  for (int i = 0; i < x.size(); ++i) {
     if (std::isnan(x[i])) {
       return true;
     }
@@ -151,7 +151,7 @@ void GaussianProcessRegressor::PosteriorPrediction(
 void GaussianProcessRegressor::ApproxFPrime(const VectorXd& x, const std::function<double(const VectorXd&)>& f,
                                             double f0, VectorXd& grad, double epsilon) {
   VectorXd ei = VectorXd::Zero(x.size());
-  for (int k = 0; k < x.size(); k++) {
+  for (int k = 0; k < x.size(); ++k) {
     ei[k] = 1.0;
     VectorXd d = epsilon * ei;
     grad[k] = (f(x + d) - f0) / d[k];

--- a/horovod/common/parameter_manager.cc
+++ b/horovod/common/parameter_manager.cc
@@ -153,7 +153,7 @@ void ParameterManager::Update(const std::vector<std::string>& tensor_names, int6
       scores_[sample_] = total_bytes_ / total_microseconds_;
       total_bytes_ = 0;
       total_microseconds_ = 0;
-      sample_++;
+      ++sample_;
       break;
     }
   }
@@ -361,7 +361,7 @@ ParameterManager::CategoricalParameter<T>::CategoricalParameter(std::vector<T> v
 
 template <class T>
 void ParameterManager::CategoricalParameter<T>::OnTune(double score, T& value) {
-  index_++;
+  ++index_;
   if (index_ < values_.size()) {
     value = values_[index_];
   }
@@ -419,7 +419,7 @@ double ParameterManager::BayesianParameter::BestValue(BayesianVariable variable)
 void ParameterManager::BayesianParameter::OnTune(double score, Eigen::VectorXd& value) {
   bayes_->AddSample(value, score);
 
-  iteration_++;
+  ++iteration_;
   if (iteration_ < test_points_.size()) {
     value = FilterTestPoint(iteration_);
   } else {
@@ -445,7 +445,7 @@ void ParameterManager::BayesianParameter::ResetBayes() {
     if (fixed_values_.find(var.variable) == fixed_values_.end()) {
       bounds.push_back(var.bounds);
       index_[var.variable] = j;
-      j++;
+      ++j;
     }
   }
 
@@ -458,11 +458,11 @@ Eigen::VectorXd ParameterManager::BayesianParameter::FilterTestPoint(int i) {
   Eigen::VectorXd filtered_point(test_point.size() - fixed_values_.size());
 
   int k = 0;
-  for (int j = 0; j < test_point.size(); j++) {
+  for (int j = 0; j < test_point.size(); ++j) {
     BayesianVariable variable = variables_[j].variable;
     if (fixed_values_.find(variable) == fixed_values_.end()) {
       filtered_point(k) = test_point(j);
-      k++;
+      ++k;
     }
   }
 

--- a/horovod/tensorflow/mpi_ops.cc
+++ b/horovod/tensorflow/mpi_ops.cc
@@ -225,7 +225,7 @@ common::Status
 TFOpContext::AllocateOutput(common::TensorShape shape,
                             std::shared_ptr<common::Tensor>* tensor) {
   TensorShape tf_shape;
-  for (int idx = 0; idx < shape.dims(); idx++) {
+  for (int idx = 0; idx < shape.dims(); ++idx) {
     tf_shape.AddDim(shape.dim_size(idx));
   }
   Tensor* tf_tensor;

--- a/horovod/torch/adapter.cc
+++ b/horovod/torch/adapter.cc
@@ -122,7 +122,7 @@ Status
 TorchOpContext<DT, Dev, T>::AllocateOutput(TensorShape shape,
                                            std::shared_ptr<Tensor>* tensor) {
   int64_t* shape_array = new int64_t[shape.dims()];
-  for (int idx = 0; idx < shape.dims(); idx++) {
+  for (int idx = 0; idx < shape.dims(); ++idx) {
     shape_array[idx] = shape.dim_size(idx);
   }
   TensorUtil::ResizeNd<DT, Dev>(output_, shape.dims(), shape_array, nullptr);

--- a/horovod/torch/adapter_v2.cc
+++ b/horovod/torch/adapter_v2.cc
@@ -61,7 +61,7 @@ const MPIDataType TorchTensor::dtype() const {
 
 const TensorShape TorchTensor::shape() const {
   TensorShape shape;
-  for (int idx = 0; idx < tensor_.dim(); idx++) {
+  for (int idx = 0; idx < tensor_.dim(); ++idx) {
     shape.AddDim(tensor_.size(idx));
   }
   return shape;
@@ -87,7 +87,8 @@ TorchOpContext::AllocatePersistent(int64_t size,
 Status TorchOpContext::AllocateOutput(TensorShape shape,
                                       std::shared_ptr<Tensor>* tensor) {
   std::vector<int64_t> shape_vector;
-  for (int idx = 0; idx < shape.dims(); idx++) {
+  shape_vector.reserve(shape.dims());
+  for (int idx = 0; idx < shape.dims(); ++idx) {
     shape_vector.push_back(shape.dim_size(idx));
   }
   with_device device_context(device_);


### PR DESCRIPTION
Change all post-increments to pre-increments where necessary to improve performance.

For example consider the following:
```
class Integer {

  public:

  // Sample implementation of pre-incrementing.
  Integer & operator++() {
    myInt += 1;
    return *this;
  }
  // Sample implementation of post-incrementing.
  const Integer operator++(int) {
    Integer temporary = *this;
    ++*this;
    return temporary;
  }

  private:

  int myInt;
};
```

The additional copy (temporary) in post-incrementing step is unnecessary.

---------------------------------------------------------------------------
Also optimized vectors which were not being reserved even though we knew
the exact number of elements that were going into it, this saves on
reallocation costs (and copies).
---------------------------------------------------------------------------