### PR TITLE
Fix out of sync error in mxnet test_broadcast

### DIFF
--- a/horovod/mxnet/__init__.py
+++ b/horovod/mxnet/__init__.py
@@ -83,12 +83,8 @@ def broadcast_parameters(params, root_rank=0):
         raise ValueError('invalid params of type: %s' % type(params))
 
     # Run broadcasts.
-    ret_list = []
     count = 0
-    for name, p in params:
+    for _, p in params:
         int_name = str(count)
         broadcast_(p, root_rank, int_name)
-        p.wait_to_read()
-        ret_list.append((name, p))
         count += 1
-    params = dict(ret_list)

--- a/horovod/mxnet/__init__.py
+++ b/horovod/mxnet/__init__.py
@@ -85,6 +85,5 @@ def broadcast_parameters(params, root_rank=0):
     # Run broadcasts.
     count = 0
     for _, p in params:
-        int_name = str(count)
-        broadcast_(p, root_rank, int_name)
+        broadcast_(p, root_rank, str(count))
         count += 1

--- a/test/test_mxnet.py
+++ b/test/test_mxnet.py
@@ -290,8 +290,6 @@ class MXTests(unittest.TestCase):
                 print("root_tensor", hvd.rank(), root_tensor)
                 print("comparison", hvd.rank(),
                       broadcast_tensor == root_tensor)
-            broadcast_tensor.wait_to_read()
-            tensor.wait_to_read()
             assert same(broadcast_tensor.asnumpy(), root_tensor.asnumpy()), \
                 'hvd.broadcast produces incorrect broadcasted tensor'
 
@@ -338,8 +336,6 @@ class MXTests(unittest.TestCase):
                 print("root_tensor", hvd.rank(), root_tensor)
                 print("comparison", hvd.rank(),
                       broadcast_tensor == root_tensor)
-            broadcast_tensor.wait_to_read()
-            tensor.wait_to_read()
             assert same(broadcast_tensor.asnumpy(), root_tensor.asnumpy()), \
                 'hvd.broadcast produces incorrect broadcasted tensor'
 

--- a/test/test_mxnet.py
+++ b/test/test_mxnet.py
@@ -321,6 +321,7 @@ class MXTests(unittest.TestCase):
             broadcast_tensor = tensor.copy()
             hvd.broadcast_(broadcast_tensor, root_rank=root_rank,
                            name=str(count))
+            broadcast_tensor.wait_to_read()
             if rank != root_rank:
                 if same(tensor.asnumpy(), root_tensor.asnumpy()):
                     print("broadcast", count, dtype, dim,

--- a/test/test_mxnet.py
+++ b/test/test_mxnet.py
@@ -273,6 +273,8 @@ class MXTests(unittest.TestCase):
 
             broadcast_tensor = hvd.broadcast(tensor, root_rank=root_rank,
                                              name=str(count))
+            # this wait is needed to avoid out of sync error between workers
+            broadcast_tensor.wait_to_read()
             if rank != root_rank:
                 if same(tensor.asnumpy(), root_tensor.asnumpy()):
                     print("broadcast", count, dtype, dim,

--- a/test/test_mxnet.py
+++ b/test/test_mxnet.py
@@ -271,8 +271,6 @@ class MXTests(unittest.TestCase):
             tensor = tensor.astype(dtype)
             root_tensor = root_tensor.astype(dtype)
 
-            # Only do broadcasting using and on broadcast_tensor
-            broadcast_tensor = tensor.copy()
             broadcast_tensor = hvd.broadcast(tensor, root_rank=root_rank,
                                              name=str(count))
             if rank != root_rank:
@@ -317,7 +315,7 @@ class MXTests(unittest.TestCase):
             tensor = tensor.astype(dtype)
             root_tensor = root_tensor.astype(dtype)
 
-            # Only do broadcasting using and on broadcast_tensor
+            # Only do broadcasting using broadcast_tensor
             broadcast_tensor = tensor.copy()
             hvd.broadcast_(broadcast_tensor, root_rank=root_rank,
                            name=str(count))


### PR DESCRIPTION
At rank 1, the `if` [block](https://github.com/uber/horovod/blob/master/test/test_mxnet.py#L276) will be processed and engine will issue a blocking call to tensor.asnumpy() and root_tensor.asnumpy().

However, this may cause out of sync error, because rank0 will skip this if block and may have already finished executing the hvd.broad_cast(tensor, root_rank) operation, which pass value of tensor to broadcast_tensor in rank 1. Adding a broadcast_tensor.wait_to_all() before the `if` block on line 276 will solve this problem. 

@yuxihu @ctcyang  please help to review.