### PR TITLE
MXNet: support aggregation in optimizer & few bugfixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,7 @@ if arg_params:
     hvd.broadcast_parameters(arg_params, root_rank=0)
 if aux_params:
     hvd.broadcast_parameters(aux_params, root_rank=0)
+model.set_params(arg_params=arg_params, aux_params=aux_params)
 
 # Train model
 model.fit(train_data,

--- a/README.md
+++ b/README.md
@@ -230,7 +230,11 @@ optimizer_params = ...
 opt = mx.optimizer.create('sgd', sym=model, **optimizer_params)
 opt = hvd.DistributedOptimizer(opt)
 
-hvd.broadcast_parameters(model.get_params(), root_rank=0)
+(arg_params, aux_params) = model.get_params()
+if arg_params:
+    hvd.broadcast_parameters(arg_params, root_rank=0)
+if aux_params:
+    hvd.broadcast_parameters(aux_params, root_rank=0)
 
 # Train model
 model.fit(train_data,

--- a/horovod/mxnet/__init__.py
+++ b/horovod/mxnet/__init__.py
@@ -93,3 +93,6 @@ def broadcast_parameters(params, root_rank=0):
     for _, p in params:
         broadcast_(p, root_rank, str(count))
         count += 1
+
+    # Make sure the tensors pushed to MXNet engine get processed
+    mx.nd.waitall()

--- a/horovod/mxnet/__init__.py
+++ b/horovod/mxnet/__init__.py
@@ -93,6 +93,6 @@ def broadcast_parameters(params, root_rank=0):
     for _, p in params:
         broadcast_(p, root_rank, str(count))
         count += 1
-
-    # Make sure the tensors pushed to MXNet engine get processed
-    p.wait_to_read()
+        if count == len(params):
+            # Make sure the tensor pushed to MXNet engine gets processed
+            p.wait_to_read()

--- a/horovod/mxnet/__init__.py
+++ b/horovod/mxnet/__init__.py
@@ -92,7 +92,7 @@ def broadcast_parameters(params, root_rank=0):
     count = 0
     for _, p in params:
         broadcast_(p, root_rank, str(count))
+        # Make sure the tensor pushed to MXNet engine gets processed
+        p.wait_to_read()
         count += 1
 
-    # Make sure the tensors pushed to MXNet engine get processed
-    mx.nd.waitall()

--- a/horovod/mxnet/__init__.py
+++ b/horovod/mxnet/__init__.py
@@ -93,6 +93,8 @@ def broadcast_parameters(params, root_rank=0):
     for _, p in params:
         broadcast_(p, root_rank, str(count))
         count += 1
-        if count == len(params):
-            # Make sure the tensor pushed to MXNet engine gets processed
-            p.wait_to_read()
+
+    # Make sure tensors pushed to MXNet engine get processed such that all
+    # workers are synced before starting training.
+    for _, p in params:
+        p.wait_to_read()

--- a/horovod/mxnet/__init__.py
+++ b/horovod/mxnet/__init__.py
@@ -92,7 +92,7 @@ def broadcast_parameters(params, root_rank=0):
     count = 0
     for _, p in params:
         broadcast_(p, root_rank, str(count))
-        # Make sure the tensor pushed to MXNet engine gets processed
-        p.wait_to_read()
         count += 1
 
+    # Make sure the tensors pushed to MXNet engine get processed
+    p.wait_to_read()

--- a/horovod/mxnet/__init__.py
+++ b/horovod/mxnet/__init__.py
@@ -43,23 +43,29 @@ class DistributedOptimizer(mx.optimizer.Optimizer):
     def create_state_multi_precision(self, index, weight):
         return self._optimizer.create_state_multi_precision(index, weight)
 
+    def _do_allreduce(self, index, grad):
+        if isinstance(index, (tuple, list)):
+            for i in range(len(index)):
+                allreduce_(grad[i], average=True, name=str(index[i]))
+        else:
+            allreduce_(grad, average=True, name=str(index))
+
     def update(self, index, weight, grad, state):
-        allreduce_(grad, average=True, name=str(index))
-        return self._optimizer.update(index, weight, grad, state)
+        self._do_allreduce(index, grad)
+        self._optimizer.update(index, weight, grad, state)
 
     def update_multi_precision(self, index, weight, grad, state):
-        allreduce_(grad, average=True, name=str(index))
-        return self._optimizer.update_multi_precision(index, weight, grad,
-                                                      state)
+        self._do_allreduce(index, grad)
+        self._optimizer.update_multi_precision(index, weight, grad, state)
 
     def set_learning_rate(self, lr):
-        return self._optimizer.set_learning_rate(lr)
+        self._optimizer.set_learning_rate(lr)
 
     def set_lr_mult(self, args_lr_mult):
-        return self._optimizer.set_lr_mult(args_lr_mult)
+        self._optimizer.set_lr_mult(args_lr_mult)
 
     def set_wd_mult(self, args_wd_mult):
-        return self._optimizer.set_wd_mult(args_wd_mult)
+        self._optimizer.set_wd_mult(args_wd_mult)
 
 
 def broadcast_parameters(params, root_rank=0):

--- a/horovod/mxnet/mpi_ops.cc
+++ b/horovod/mxnet/mpi_ops.cc
@@ -204,7 +204,7 @@ extern "C" int horovod_mxnet_allreduce_async(NDArray* input, NDArray* output,
     Engine::Get()->PushAsync(allreduce_async_cpu_fn, input->ctx(),
                              {input->var()}, {output->var()},
                              FnProperty::kNormal, 0, "HorovodAllreduce");
-    // In-place
+  // In-place
   } else {
     Engine::Get()->PushAsync(allreduce_async_cpu_fn, input->ctx(), {},
                              {output->var()}, FnProperty::kNormal, 0,
@@ -216,7 +216,7 @@ extern "C" int horovod_mxnet_allreduce_async(NDArray* input, NDArray* output,
     Engine::Get()->PushAsync(allreduce_async_fn, input->ctx(), {input->var()},
                              {output->var()}, FnProperty::kNormal, 0,
                              "HorovodAllreduce");
-    // In-place
+  // In-place
   } else {
     Engine::Get()->PushAsync(allreduce_async_fn, input->ctx(), {},
                              {output->var()}, FnProperty::kNormal, 0,
@@ -256,18 +256,19 @@ extern "C" int horovod_mxnet_allgather_async(NDArray* input, NDArray* output,
     Engine::Get()->PushAsync(allgather_async_cpu_fn, input->ctx(),
                              {input->var()}, {output->var()},
                              FnProperty::kNormal, 0, "HorovodAllgather");
-    // In-place
+  // In-place
   } else {
     Engine::Get()->PushAsync(allgather_async_cpu_fn, input->ctx(), {},
                              {output->var()}, FnProperty::kNormal, 0,
                              "HorovodAllgather");
   }
 #else
+  // Not in-place
   if (input->var() != output->var()) {
     Engine::Get()->PushAsync(allgather_async_fn, input->ctx(),
                              {input->var()}, {output->var()},
                              FnProperty::kNormal, 0, "HorovodAllgather");
-    // In-place
+  // In-place
   } else {
     Engine::Get()->PushAsync(allgather_async_fn, input->ctx(), {},
                              {output->var()}, FnProperty::kNormal, 0,
@@ -290,7 +291,6 @@ extern "C" int horovod_mxnet_broadcast_async(NDArray* input, NDArray* output,
   };
 
 #if HAVE_CUDA && HOROVOD_GPU_BROADCAST != 'M'
-  // Not in-place
   ThrowIfError(common::CheckInitialized());
   // Make async copy of input tensor to CPU tensor and record completion event.
   auto hvd_cpu_buffer = std::make_shared<MXTemporaryBuffer<NDArray>>(
@@ -302,15 +302,31 @@ extern "C" int horovod_mxnet_broadcast_async(NDArray* input, NDArray* output,
           DoBroadcastCudaOnCPU(hvd_cpu_buffer, root_rank, op_name, on_complete);
         };
 
-  Engine::Get()->PushAsync(broadcast_async_cpu_fn, input->ctx(), {},
-                           {output->var()}, FnProperty::kNormal, 0,
-                           "HorovodBroadcast");
+  // Not in-place
+  if (input->var() != output->var()) {
+    Engine::Get()->PushAsync(broadcast_async_cpu_fn, input->ctx(),
+                             {input->var()}, {output->var()},
+                             FnProperty::kNormal, 0, "HorovodBroadcast");
+  // In-place
+  } else {
+    Engine::Get()->PushAsync(broadcast_async_cpu_fn, input->ctx(), {},
+                             {output->var()}, FnProperty::kNormal, 0,
+                             "HorovodBroadcast");
+  }
 
   TensorUtil::CopyCPUToCuda(hvd_cpu_buffer->tensor(), output);
 #else
-  Engine::Get()->PushAsync(broadcast_async_fn, input->ctx(), {},
-                           {output->var()}, FnProperty::kNormal, 0,
-                           "HorovodBroadcast");
+  // Not in-place
+  if (input->var() != output->var()) {
+    Engine::Get()->PushAsync(broadcast_async_fn, input->ctx(), {input->var()},
+                             {output->var()}, FnProperty::kNormal, 0,
+                             "HorovodBroadcast");
+  // In-place
+  } else {
+    Engine::Get()->PushAsync(broadcast_async_fn, input->ctx(), {},
+                             {output->var()}, FnProperty::kNormal, 0,
+                             "HorovodBroadcast");
+  }
 #endif
 
   MX_API_END();


### PR DESCRIPTION
Recently we add [aggregated updates](https://github.com/apache/incubator-mxnet/pull/13346) in MXNet for SGD optimizer. The same aggregation behavior will extend to other optimizers. This requires changes in Horovod's DistributedOptimizer wrapper for MXNet to support allreduce multiple tensors in a single update call. This PR is to add this support. We are also working to add CI in MXNet for Horovod to identify such breaking API changes.

In addition, we fixed two issues:
1. We add a sync point in broadcast_parameters to make sure tensors pushed to MXNet engine got processed to avoid potential duplicate name error.
2. We fix horovod_mxnet_broadcast_async function to do in-place and not-in-place broadcast correctly. Thanks @alsrgv for pointing it out.