### PR TITLE
Improved autotuning scoring and parameter search process

### DIFF
--- a/horovod/common/operations.cc
+++ b/horovod/common/operations.cc
@@ -2278,10 +2278,7 @@ bool RunLoopOnce(HorovodGlobalState& state, bool is_coordinator) {
     }
 
     if (state.param_manager.IsAutoTuning()) {
-      double duration = std::chrono::duration_cast<std::chrono::microseconds>(
-                            std::chrono::steady_clock::now() - start_time)
-                            .count();
-      state.param_manager.Update(tensor_names, total_tensor_size, duration);
+      state.param_manager.Update(tensor_names, total_tensor_size);
     }
   } else {
     std::string encoded_message;
@@ -2331,7 +2328,7 @@ bool RunLoopOnce(HorovodGlobalState& state, bool is_coordinator) {
     }
 
     if (state.param_manager.IsAutoTuning()) {
-      state.param_manager.Update(tensor_names, total_tensor_size, 1.0);
+      state.param_manager.Update(tensor_names, total_tensor_size);
     }
 
     if (response_list.shutdown()) {

--- a/horovod/common/optim/bayesian_optimization.cc
+++ b/horovod/common/optim/bayesian_optimization.cc
@@ -37,7 +37,7 @@ void GetSufficientStats(std::vector<double>& v, double* mu, double* sigma) {
   *mu = sum / v.size();
 
   std::vector<double> diff(v.size());
-  std::transform(v.begin(), v.end(), diff.begin(), std::bind2nd(std::minus<double>(), *mu));
+  std::transform(v.begin(), v.end(), diff.begin(), [mu](double& x) { return x - *mu; });
   double sq_sum = std::inner_product(diff.begin(), diff.end(), diff.begin(), 0.0);
   *sigma = std::sqrt(sq_sum / v.size());
 }

--- a/horovod/common/optim/bayesian_optimization.cc
+++ b/horovod/common/optim/bayesian_optimization.cc
@@ -80,7 +80,6 @@ VectorXd BayesianOptimization::NextSample(bool normalize) {
   MatrixXd y_sample(y_samples_.size(), 1);
   for (unsigned int i = 0; i < y_samples_.size(); ++i) {
     double norm_score = (y_samples_[i] - mu) / sigma;
-//    std::cout << "norm_score[" << i << "] = " << norm_score << std::endl;
 
     VectorXd y_i(1);
     y_i(0) = norm_score;

--- a/horovod/common/optim/bayesian_optimization.cc
+++ b/horovod/common/optim/bayesian_optimization.cc
@@ -18,6 +18,7 @@
 
 #include <cmath>
 #include <iostream>
+#include <numeric>
 
 #include <Eigen/LU>
 
@@ -30,6 +31,16 @@ namespace horovod {
 namespace common {
 
 const double NORM_PDF_C = std::sqrt(2 * M_PI);
+
+void GetSufficientStats(std::vector<double>& v, double* mu, double* sigma) {
+  double sum = std::accumulate(v.begin(), v.end(), 0.0);
+  *mu = sum / v.size();
+
+  std::vector<double> diff(v.size());
+  std::transform(v.begin(), v.end(), diff.begin(), std::bind2nd(std::minus<double>(), *mu));
+  double sq_sum = std::inner_product(diff.begin(), diff.end(), diff.begin(), 0.0);
+  *sigma = std::sqrt(sq_sum / v.size());
+}
 
 // Returns a list of distributions that generate real values uniformly and random between the bounds.
 std::vector<std::uniform_real_distribution<>> GetDistributions(std::vector<std::pair<double, double>> bounds) {
@@ -49,17 +60,17 @@ BayesianOptimization::BayesianOptimization(std::vector<std::pair<double, double>
       gpr_(GaussianProcessRegressor(alpha)) {}
 
 void BayesianOptimization::AddSample(const Eigen::VectorXd& x, double y) {
-  VectorXd y_v(1);
-  y_v << y;
-  AddSample(x, y_v);
-}
-
-void BayesianOptimization::AddSample(const Eigen::VectorXd& x, const Eigen::VectorXd& y) {
   x_samples_.push_back(x);
   y_samples_.push_back(y);
 }
 
-VectorXd BayesianOptimization::NextSample() {
+VectorXd BayesianOptimization::NextSample(bool normalize) {
+  double mu = 0.0;
+  double sigma = 1.0;
+  if (normalize && y_samples_.size() >= 3) {
+    GetSufficientStats(y_samples_, &mu, &sigma);
+  }
+
   // Matrices are immutable and must be regenerated each time a new sample is added.
   MatrixXd x_sample(x_samples_.size(), d_);
   for (unsigned int i = 0; i < x_samples_.size(); ++i) {
@@ -68,7 +79,12 @@ VectorXd BayesianOptimization::NextSample() {
 
   MatrixXd y_sample(y_samples_.size(), 1);
   for (unsigned int i = 0; i < y_samples_.size(); ++i) {
-    y_sample.row(i) = y_samples_[i];
+    double norm_score = (y_samples_[i] - mu) / sigma;
+//    std::cout << "norm_score[" << i << "] = " << norm_score << std::endl;
+
+    VectorXd y_i(1);
+    y_i(0) = norm_score;
+    y_sample.row(i) = y_i;
   }
 
   // Generate the posterior distribution for the GP given the observed data.

--- a/horovod/common/optim/bayesian_optimization.h
+++ b/horovod/common/optim/bayesian_optimization.h
@@ -66,7 +66,7 @@ public:
 
   // Provides the next sample point to evaluate subject to maximizing the
   // expected improvement of the target acquisition function.
-  Eigen::VectorXd NextSample();
+  Eigen::VectorXd NextSample(bool normalize=true);
 
   // Reset the state of the optimizer by clearing all samples.
   void Clear();
@@ -107,7 +107,7 @@ private:
 
   GaussianProcessRegressor gpr_;
   std::vector<Eigen::VectorXd> x_samples_;
-  std::vector<Eigen::VectorXd> y_samples_;
+  std::vector<double> y_samples_;
 };
 
 } // namespace common

--- a/horovod/common/optim/bayesian_optimization.h
+++ b/horovod/common/optim/bayesian_optimization.h
@@ -62,8 +62,6 @@ public:
   //  y: Evaluated objective value at x.
   void AddSample(const Eigen::VectorXd& x, double y);
 
-  void AddSample(const Eigen::VectorXd& x, const Eigen::VectorXd& y);
-
   // Provides the next sample point to evaluate subject to maximizing the
   // expected improvement of the target acquisition function.
   Eigen::VectorXd NextSample(bool normalize=true);

--- a/horovod/common/parameter_manager.cc
+++ b/horovod/common/parameter_manager.cc
@@ -150,9 +150,13 @@ void ParameterManager::Update(const std::vector<std::string>& tensor_names, int6
   for (const std::string& tensor_name : tensor_names) {
     int32_t cycle = tensor_counts_[tensor_name]++;
     if (cycle > sample_ * CYCLES_PER_SAMPLE) {
-      scores_[sample_] = total_bytes_ / total_microseconds_;
+      auto now = std::chrono::steady_clock::now();
+      double duration = std::chrono::duration_cast<std::chrono::microseconds>(now - last_cycle_start_).count();
+      scores_[sample_] = total_bytes_ / duration;
+
       total_bytes_ = 0;
       total_microseconds_ = 0;
+      last_cycle_start_ = now;
       ++sample_;
       break;
     }
@@ -246,6 +250,7 @@ void ParameterManager::SyncParams() {
 void ParameterManager::Reset() {
   total_bytes_ = 0;
   total_microseconds_ = 0;
+  last_cycle_start_ = std::chrono::steady_clock::now();
   tensor_counts_.clear();
   sample_ = 0;
 }

--- a/horovod/common/parameter_manager.cc
+++ b/horovod/common/parameter_manager.cc
@@ -149,7 +149,7 @@ void ParameterManager::Update(const std::vector<std::string>& tensor_names, int6
 
   for (const std::string& tensor_name : tensor_names) {
     int32_t cycle = tensor_counts_[tensor_name]++;
-    if (cycle > sample_ * CYCLES_PER_SAMPLE) {
+    if (cycle >= (sample_ + 1) * CYCLES_PER_SAMPLE) {
       auto now = std::chrono::steady_clock::now();
       double duration = std::chrono::duration_cast<std::chrono::microseconds>(now - last_cycle_start_).count();
       scores_[sample_] = total_bytes_ / duration;

--- a/horovod/common/parameter_manager.cc
+++ b/horovod/common/parameter_manager.cc
@@ -28,7 +28,7 @@ namespace common {
 #define WARMUPS 3
 #define CYCLES_PER_SAMPLE 10
 #define BAYES_OPT_MAX_SAMPLES 20
-#define GAUSSIAN_PROCESS_NOISE 0.2
+#define GAUSSIAN_PROCESS_NOISE 0.8
 
 Eigen::VectorXd CreateVector(double x1, double x2) {
   Eigen::VectorXd v(2);

--- a/horovod/common/parameter_manager.h
+++ b/horovod/common/parameter_manager.h
@@ -18,6 +18,7 @@
 
 #include "optim/bayesian_optimization.h"
 
+#include <chrono>
 #include <fstream>
 #include <iostream>
 #include <memory>
@@ -213,6 +214,7 @@ private:
 
   int64_t total_bytes_;
   double total_microseconds_;
+  std::chrono::steady_clock::time_point last_cycle_start_;
   std::unordered_map<std::string, int32_t> tensor_counts_;
 
   int32_t rank_;

--- a/horovod/common/parameter_manager.h
+++ b/horovod/common/parameter_manager.h
@@ -86,7 +86,7 @@ public:
   //  tensor_names: The names of the tensors that have been processed.
   //  bytes: The number of bytes that were processed per worker.
   //  microseconds: The number of microseconds taken to process the bytes on this worker.
-  void Update(const std::vector<std::string>& tensor_names, int64_t bytes, double microseconds);
+  void Update(const std::vector<std::string>& tensor_names, int64_t bytes);
 
 private:
   // Adjusts the parameter values based on the last observed score.
@@ -213,8 +213,7 @@ private:
   int32_t sample_;
 
   int64_t total_bytes_;
-  double total_microseconds_;
-  std::chrono::steady_clock::time_point last_cycle_start_;
+  std::chrono::steady_clock::time_point last_sample_start_;
   std::unordered_map<std::string, int32_t> tensor_counts_;
 
   int32_t rank_;


### PR DESCRIPTION
- Use time between samples instead of aggregated time spent in the background thread for computing sample score
- Normalized scores after each sample to focus the Bayesian optimization more on certain ranges of parameters
- Increased noise parameter from 0.2 -> 0.8 to reflect apriori entropy expectations in samples